### PR TITLE
feat(events): add events table and organizer relation

### DIFF
--- a/backend/src/events/entities/event.entity.ts
+++ b/backend/src/events/entities/event.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('events')
+export class Event {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  title!: string;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column({ type: 'timestamp' })
+  eventDate!: Date;
+
+  @Column({ nullable: true })
+  location?: string;
+
+  @Column({ type: 'int', default: 1 })
+  capacity!: number;
+
+  @ManyToOne(() => User, (user) => user.organizedEvents, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'organizerId' })
+  organizer!: User;
+
+  @Column({ type: 'uuid' })
+  organizerId!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/events/events.module.ts
+++ b/backend/src/events/events.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventsService } from './events.service';
 import { EventsController } from './events.controller';
+import { Event } from './entities/event.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Event])],
   providers: [EventsService],
   controllers: [EventsController],
 })

--- a/backend/src/migrations/1760000002000-CreateEventsTable.ts
+++ b/backend/src/migrations/1760000002000-CreateEventsTable.ts
@@ -1,0 +1,87 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateEventsTable1760000002000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'events',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'title',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'eventDate',
+            type: 'timestamp',
+            isNullable: false,
+          },
+          {
+            name: 'location',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'capacity',
+            type: 'int',
+            default: '1',
+            isNullable: false,
+          },
+          {
+            name: 'organizerId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'now()',
+            isNullable: false,
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'events',
+      new TableForeignKey({
+        columnNames: ['organizerId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('events');
+    const organizerForeignKey = table?.foreignKeys.find((foreignKey) =>
+      foreignKey.columnNames.includes('organizerId'),
+    );
+
+    if (organizerForeignKey) {
+      await queryRunner.dropForeignKey('events', organizerForeignKey);
+    }
+
+    await queryRunner.dropTable('events');
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -3,7 +3,9 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  OneToMany,
 } from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
 
 @Entity('users')
 export class User {
@@ -21,4 +23,7 @@ export class User {
 
   @CreateDateColumn()
   createdAt!: Date;
+
+  @OneToMany(() => Event, (event) => event.organizer)
+  organizedEvents!: Event[];
 }


### PR DESCRIPTION
Summary
Adds the initial events data model and links each event to its organizer user.

What changed
Introduced [Event](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) entity mapped to events table.
Added relation users (1) -> (N) events via organizerId.
Updated [User](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) entity with [organizedEvents](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) relation.
Wired [EventsModule](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [TypeOrmModule.forFeature([Event])](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Added migration to create events table and foreign key to [users(id)](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Why
This establishes the core event ownership model required before implementing event CRUD and participation features.

How to test
Run [npm --prefix backend run build](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Run npm --prefix backend run migration:run.
Check tables in DB (\dt) and confirm events exists.
(Optional) Verify FK: [events.organizerId -> users.id](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with ON DELETE CASCADE.

Notes
Scope is intentionally limited to schema/module wiring only (no new event endpoints yet).