### PR TITLE
refactor(backend): simplify events tags resolution pipeline

### DIFF
--- a/backend/src/events/events-tags.helpers.ts
+++ b/backend/src/events/events-tags.helpers.ts
@@ -4,6 +4,24 @@ import type { Tag } from '../tags/entities/tag.entity';
 import { MAX_EVENT_TAGS } from './events-validation.helpers';
 
 type TagsRepository = Pick<Repository<Tag>, 'find' | 'save' | 'create'>;
+type DriverErrorCode = {
+  code?: string;
+  errno?: number;
+};
+
+const POSTGRES_UNIQUE_VIOLATION_CODE = '23505';
+
+const isUniqueViolationError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const code =
+    (error as { code?: string }).code ??
+    (error as { driverError?: DriverErrorCode }).driverError?.code;
+
+  return code === POSTGRES_UNIQUE_VIOLATION_CODE;
+};
 
 const normalizeAndValidateTagNames = (
   tags: string[] | undefined,
@@ -101,8 +119,12 @@ export const resolveEventTags = async (
 
   try {
     createdTags = await createMissingTags(tagsRepository, missingNames);
-  } catch {
-    // Recover from concurrent insert races by re-reading normalized names.
+  } catch (error) {
+    if (!isUniqueViolationError(error)) {
+      throw error;
+    }
+
+    // Recover from concurrent insert races only for expected unique conflicts.
     return loadRefreshedResolvedTags(tagsRepository, normalizedTags);
   }
 

--- a/backend/src/events/events-tags.helpers.ts
+++ b/backend/src/events/events-tags.helpers.ts
@@ -3,15 +3,17 @@ import type { Repository } from 'typeorm';
 import type { Tag } from '../tags/entities/tag.entity';
 import { MAX_EVENT_TAGS } from './events-validation.helpers';
 
-export const resolveEventTags = async (
-  tagsRepository: Pick<Repository<Tag>, 'find' | 'save' | 'create'>,
-  tags?: string[],
-  maxEventTags = MAX_EVENT_TAGS,
-): Promise<Tag[]> => {
+type TagsRepository = Pick<Repository<Tag>, 'find' | 'save' | 'create'>;
+
+const normalizeAndValidateTagNames = (
+  tags: string[] | undefined,
+  maxEventTags: number,
+): string[] => {
   if (!tags || tags.length === 0) {
     return [];
   }
 
+  // Normalize early so uniqueness and max-limit checks are deterministic.
   const normalizedTags = [
     ...new Set(tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean)),
   ];
@@ -26,47 +28,87 @@ export const resolveEventTags = async (
     );
   }
 
+  return normalizedTags;
+};
+
+const mapTagsByName = (tags: Tag[]): Map<string, Tag> =>
+  new Map(tags.map((tag) => [tag.name, tag]));
+
+const mapNamesToExistingTags = (
+  normalizedTags: string[],
+  tagsByName: Map<string, Tag>,
+): Tag[] =>
+  // Return tags in the same order as user input after normalization.
+  normalizedTags
+    .map((name) => tagsByName.get(name))
+    .filter((tag): tag is Tag => Boolean(tag));
+
+const loadExistingTagsByName = async (
+  tagsRepository: TagsRepository,
+  normalizedTags: string[],
+): Promise<Map<string, Tag>> => {
   const existingTags = await tagsRepository.find({
     where: normalizedTags.map((name) => ({ name })),
   });
 
-  const existingByName = new Map(existingTags.map((tag) => [tag.name, tag]));
+  return mapTagsByName(existingTags);
+};
+
+const createMissingTags = async (
+  tagsRepository: TagsRepository,
+  missingNames: string[],
+): Promise<Tag[]> =>
+  tagsRepository.save(
+    missingNames.map((name) => tagsRepository.create({ name })),
+  );
+
+const loadRefreshedResolvedTags = async (
+  tagsRepository: TagsRepository,
+  normalizedTags: string[],
+): Promise<Tag[]> => {
+  const refreshedTagsByName = await loadExistingTagsByName(
+    tagsRepository,
+    normalizedTags,
+  );
+
+  return mapNamesToExistingTags(normalizedTags, refreshedTagsByName);
+};
+
+export const resolveEventTags = async (
+  tagsRepository: TagsRepository,
+  tags?: string[],
+  maxEventTags = MAX_EVENT_TAGS,
+): Promise<Tag[]> => {
+  const normalizedTags = normalizeAndValidateTagNames(tags, maxEventTags);
+
+  if (normalizedTags.length === 0) {
+    return [];
+  }
+
+  const existingByName = await loadExistingTagsByName(
+    tagsRepository,
+    normalizedTags,
+  );
   const missingNames = normalizedTags.filter(
     (name) => !existingByName.has(name),
   );
 
   if (missingNames.length === 0) {
-    return normalizedTags
-      .map((name) => existingByName.get(name))
-      .filter((tag): tag is Tag => Boolean(tag));
+    return mapNamesToExistingTags(normalizedTags, existingByName);
   }
 
-  let newTags: Tag[] = [];
+  let createdTags: Tag[] = [];
 
   try {
-    newTags = await tagsRepository.save(
-      missingNames.map((name) => tagsRepository.create({ name })),
-    );
+    createdTags = await createMissingTags(tagsRepository, missingNames);
   } catch {
-    // Another request may have inserted the same normalized tag names.
-    const refreshedTags = await tagsRepository.find({
-      where: normalizedTags.map((name) => ({ name })),
-    });
-
-    const refreshedByName = new Map(
-      refreshedTags.map((tag) => [tag.name, tag]),
-    );
-
-    return normalizedTags
-      .map((name) => refreshedByName.get(name))
-      .filter((tag): tag is Tag => Boolean(tag));
+    // Recover from concurrent insert races by re-reading normalized names.
+    return loadRefreshedResolvedTags(tagsRepository, normalizedTags);
   }
 
-  for (const tag of newTags) {
+  for (const tag of createdTags) {
     existingByName.set(tag.name, tag);
   }
 
-  return normalizedTags
-    .map((name) => existingByName.get(name))
-    .filter((tag): tag is Tag => Boolean(tag));
+  return mapNamesToExistingTags(normalizedTags, existingByName);
 };

--- a/backend/src/events/events.service.spec.ts
+++ b/backend/src/events/events.service.spec.ts
@@ -316,7 +316,9 @@ describe('EventsService', () => {
     tagsRepository.create.mockImplementation(
       (payload: Record<string, unknown>) => payload,
     );
-    tagsRepository.save.mockRejectedValue(new Error('duplicate key value'));
+    tagsRepository.save.mockRejectedValue({
+      driverError: { code: '23505' },
+    });
 
     eventsRepository.create.mockImplementation(
       (payload: Record<string, unknown>) => payload,
@@ -338,6 +340,32 @@ describe('EventsService', () => {
     expect(tagsRepository.save).toHaveBeenCalledTimes(1);
     expect(tagsRepository.find).toHaveBeenCalledTimes(2);
     expect(result.tags).toHaveLength(2);
+  });
+
+  it('create rethrows tags save error when it is not a unique conflict', async () => {
+    const user = { sub: 'user-id', email: 'user@example.com' };
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const dbError = new Error('database unavailable');
+
+    tagsRepository.find.mockResolvedValue([{ id: 'tag-1', name: 'tech' }]);
+    tagsRepository.create.mockImplementation(
+      (payload: Record<string, unknown>) => payload,
+    );
+    tagsRepository.save.mockRejectedValue(dbError);
+
+    await expect(
+      service.create(
+        {
+          title: 'Non-conflict tags error event',
+          eventDate: futureDate,
+          location: 'Kyiv',
+          tags: ['Tech', 'Art'],
+        },
+        user,
+      ),
+    ).rejects.toBe(dbError);
+
+    expect(tagsRepository.find).toHaveBeenCalledTimes(1);
   });
 
   it('create ignores whitespace-only tags input', async () => {


### PR DESCRIPTION
What changed

Split tag resolution into focused steps: normalize/validate, load existing, create missing, and conflict recovery.
Kept resolveEventTags behavior and contract unchanged.
Why

Make the flow easier to read, maintain, and test.
Reduce complexity in the helper while preserving current create/update behavior.
Validation

Targeted tests passed: events.service.spec.ts
Full backend test suite passed.
Close #38 