### PR TITLE
refactor(backend): split assistant service responsibilities

### DIFF
--- a/backend/src/assistant/assistant-data.service.ts
+++ b/backend/src/assistant/assistant-data.service.ts
@@ -1,0 +1,156 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  Event as EventEntity,
+  EventVisibility,
+} from '../events/entities/event.entity';
+import { mergeAndSortCalendarEvents } from '../events/events.service.helpers';
+import { Participant } from '../participants/entities/participant.entity';
+import type { AssistantContextSnapshot } from './assistant-llm.service';
+import type { AssistantEvent } from './assistant.types';
+
+@Injectable()
+export class AssistantDataService {
+  constructor(
+    @InjectRepository(EventEntity)
+    private readonly eventsRepository: Repository<EventEntity>,
+    @InjectRepository(Participant)
+    private readonly participantsRepository: Repository<Participant>,
+  ) {}
+
+  async loadUserEvents(userId: string): Promise<AssistantEvent[]> {
+    // Read organizer and participant views in parallel, then merge unique events.
+    const [organizedEvents, participantRows] = await Promise.all([
+      this.eventsRepository.find({
+        where: { organizerId: userId },
+        relations: ['tags', 'participants', 'participants.user'],
+      }),
+      this.participantsRepository.find({
+        where: { userId },
+        relations: [
+          'event',
+          'event.tags',
+          'event.participants',
+          'event.participants.user',
+        ],
+      }),
+    ]);
+
+    const mergedEvents = mergeAndSortCalendarEvents(
+      organizedEvents,
+      participantRows,
+    );
+
+    return this.toAssistantEvents(mergedEvents);
+  }
+
+  async loadPublicLookupEvents(
+    seedEvents: AssistantEvent[],
+  ): Promise<AssistantEvent[]> {
+    const publicEvents = await this.eventsRepository.find({
+      where: { visibility: EventVisibility.PUBLIC },
+      relations: ['tags', 'participants', 'participants.user'],
+    });
+
+    const mappedPublicEvents = this.toAssistantEvents(publicEvents);
+    const byId = new Map<string, AssistantEvent>();
+
+    seedEvents.forEach((event) => byId.set(event.id, event));
+    mappedPublicEvents.forEach((event) => {
+      if (!byId.has(event.id)) {
+        byId.set(event.id, event);
+      }
+    });
+
+    return [...byId.values()];
+  }
+
+  buildSnapshot(
+    events: AssistantEvent[],
+    now: Date,
+    userId: string,
+    includeParticipantIdentifiers: boolean,
+  ): AssistantContextSnapshot {
+    const sortedDates = events
+      .map((event) => event.eventDate)
+      .sort((first, second) => first.getTime() - second.getTime());
+
+    const tags = [
+      ...new Set(
+        events.flatMap((event) => event.tags).map((tag) => tag.toLowerCase()),
+      ),
+    ].sort();
+
+    return {
+      currentUserId: userId,
+      generatedAt: now.toISOString(),
+      dateWindow: {
+        earliestEventDate: sortedDates[0]?.toISOString() ?? null,
+        latestEventDate: sortedDates.at(-1)?.toISOString() ?? null,
+      },
+      eventCount: events.length,
+      tags,
+      events: events.map((event) => {
+        const eventSnapshot = {
+          title: event.title,
+          eventDate: event.eventDate.toISOString(),
+          visibility: event.visibility,
+          relationToUser:
+            event.organizerId === userId
+              ? ('organizer' as const)
+              : event.participantIds.includes(userId)
+                ? ('participant' as const)
+                : ('unrelated' as const),
+          location: event.location,
+          tags: event.tags,
+          participantCount: event.participantIds.length,
+        };
+
+        if (includeParticipantIdentifiers) {
+          return {
+            ...eventSnapshot,
+            participantIds: event.participantIds,
+          };
+        }
+
+        return eventSnapshot;
+      }),
+    };
+  }
+
+  private toAssistantEvents(events: EventEntity[]): AssistantEvent[] {
+    return events.map((event) => {
+      // TypeORM relation typing can be narrower than runtime-loaded relations.
+      const typedEvent = event as EventEntity & {
+        tags?: Array<{ name: string }>;
+        participants?: Array<{
+          userId: string;
+          user?: { name?: string | null; email?: string | null };
+        }>;
+      };
+
+      return {
+        id: event.id,
+        title: event.title,
+        eventDate: new Date(event.eventDate),
+        visibility: event.visibility,
+        location: event.location,
+        organizerId: event.organizerId,
+        tags: (typedEvent.tags ?? []).map((tag) => tag.name),
+        participantIds: (typedEvent.participants ?? []).map(
+          (row) => row.userId,
+        ),
+        participantLabels: (typedEvent.participants ?? []).map((row) => {
+          const name = row.user?.name?.trim();
+
+          if (name) {
+            return name;
+          }
+
+          return row.userId;
+        }),
+      };
+    });
+  }
+}

--- a/backend/src/assistant/assistant-fallback.resolver.spec.ts
+++ b/backend/src/assistant/assistant-fallback.resolver.spec.ts
@@ -1,0 +1,60 @@
+import { AssistantFallbackResolver } from './assistant-fallback.resolver';
+import type { AssistantEvent } from './assistant.types';
+
+describe('AssistantFallbackResolver', () => {
+  const now = new Date('2026-03-12T10:00:00.000Z');
+
+  const events: AssistantEvent[] = [
+    {
+      id: 'event-1',
+      title: 'Open House',
+      eventDate: new Date('2026-03-20T18:00:00.000Z'),
+      visibility: 'public',
+      organizerId: 'user-3',
+      location: 'Main Hall',
+      tags: ['community'],
+      participantIds: ['user-1', 'user-2'],
+      participantLabels: ['Ira', 'Maks'],
+    },
+  ];
+
+  it('resolves participants fallback first', () => {
+    const resolver = new AssistantFallbackResolver();
+
+    const result = resolver.resolve(
+      "Who's attending the Open House?",
+      events,
+      now,
+    );
+
+    expect(result.source).toBe('heuristic-participants');
+    expect(result.answer).toBe('Participants for "Open House": Ira, Maks.');
+  });
+
+  it('resolves location fallback for where-is questions', () => {
+    const resolver = new AssistantFallbackResolver();
+
+    const result = resolver.resolve('Where is Open House?', events, now);
+
+    expect(result.source).toBe('heuristic-where-is');
+    expect(result.answer).toBe('"Open House" is at Main Hall.');
+  });
+
+  it('uses local date rules only for date-oriented fallback questions', () => {
+    const resolver = new AssistantFallbackResolver();
+
+    const result = resolver.resolve('Show events on 2026-03-20', events, now);
+
+    expect(result.source).toBe('local-rules-fallback');
+    expect(result.answer).toContain('Events on 20-03-2026:');
+  });
+
+  it('returns transparent fallback for unsupported questions', () => {
+    const resolver = new AssistantFallbackResolver();
+
+    const result = resolver.resolve('How many events do I have?', events, now);
+
+    expect(result.source).toBe('heuristic-fallback');
+    expect(result.answer).toBeNull();
+  });
+});

--- a/backend/src/assistant/assistant-fallback.resolver.ts
+++ b/backend/src/assistant/assistant-fallback.resolver.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import {
+  answerFromRules,
+  answerParticipantsFromQuestion,
+  answerWhereIsFromQuestion,
+} from './assistant-answer.helpers';
+import { shouldUseDateFallbackQuestion } from './assistant-text.helpers';
+import type { AssistantEvent } from './assistant.types';
+
+export type AssistantFallbackSource =
+  | 'heuristic-participants'
+  | 'heuristic-where-is'
+  | 'local-rules-fallback'
+  | 'heuristic-fallback';
+
+export type AssistantFallbackResolution = {
+  source: AssistantFallbackSource;
+  answer: string | null;
+};
+
+@Injectable()
+export class AssistantFallbackResolver {
+  resolve(
+    question: string,
+    events: AssistantEvent[],
+    now: Date,
+  ): AssistantFallbackResolution {
+    // Single transparent fallback path: participants -> where-is -> date rules.
+    const participantsAnswer = answerParticipantsFromQuestion(question, events);
+
+    if (participantsAnswer) {
+      return {
+        source: 'heuristic-participants',
+        answer: participantsAnswer,
+      };
+    }
+
+    const locationAnswer = answerWhereIsFromQuestion(question, events);
+
+    if (locationAnswer) {
+      return {
+        source: 'heuristic-where-is',
+        answer: locationAnswer,
+      };
+    }
+
+    if (shouldUseDateFallbackQuestion(question)) {
+      const localFallbackAnswer = answerFromRules(question, events, now);
+
+      if (localFallbackAnswer) {
+        return {
+          source: 'local-rules-fallback',
+          answer: localFallbackAnswer,
+        };
+      }
+    }
+
+    return {
+      source: 'heuristic-fallback',
+      answer: null,
+    };
+  }
+}

--- a/backend/src/assistant/assistant-scope.resolver.spec.ts
+++ b/backend/src/assistant/assistant-scope.resolver.spec.ts
@@ -1,0 +1,108 @@
+import { AssistantScopeResolver } from './assistant-scope.resolver';
+import type {
+  AssistantEvent,
+  AssistantQuestionIntent,
+} from './assistant.types';
+
+describe('AssistantScopeResolver', () => {
+  const userEvents: AssistantEvent[] = [
+    {
+      id: 'event-1',
+      title: 'Tech Meetup',
+      eventDate: new Date('2026-03-13T12:00:00.000Z'),
+      visibility: 'public',
+      organizerId: 'user-1',
+      location: 'Main Hall',
+      tags: ['tech'],
+      participantIds: ['user-2'],
+      participantLabels: ['Alex'],
+    },
+  ];
+
+  const globalEvents: AssistantEvent[] = [
+    ...userEvents,
+    {
+      id: 'event-2',
+      title: 'Open House',
+      eventDate: new Date('2026-03-20T18:00:00.000Z'),
+      visibility: 'public',
+      organizerId: 'user-3',
+      location: 'City Center',
+      tags: ['community'],
+      participantIds: [],
+      participantLabels: [],
+    },
+  ];
+
+  it('keeps user scope for personal date questions', async () => {
+    const assistantDataService = {
+      loadPublicLookupEvents: jest.fn().mockResolvedValue(globalEvents),
+    };
+    const resolver = new AssistantScopeResolver(assistantDataService as never);
+
+    const result = await resolver.resolveContextEvents(
+      'Show my events from 2026-03-10 to 2026-03-20',
+      userEvents,
+    );
+
+    expect(result).toEqual(userEvents);
+    expect(assistantDataService.loadPublicLookupEvents).not.toHaveBeenCalled();
+  });
+
+  it('expands to global scope for non-personal date questions', async () => {
+    const assistantDataService = {
+      loadPublicLookupEvents: jest.fn().mockResolvedValue(globalEvents),
+    };
+    const resolver = new AssistantScopeResolver(assistantDataService as never);
+
+    const result = await resolver.resolveContextEvents(
+      'Show events from 2026-03-10 to 2026-03-20',
+      userEvents,
+    );
+
+    expect(result).toEqual(globalEvents);
+    expect(assistantDataService.loadPublicLookupEvents).toHaveBeenCalledWith(
+      userEvents,
+    );
+  });
+
+  it('uses global lookup for location and participants intents', async () => {
+    const assistantDataService = {
+      loadPublicLookupEvents: jest.fn().mockResolvedValue(globalEvents),
+    };
+    const resolver = new AssistantScopeResolver(assistantDataService as never);
+
+    const whereIntent: AssistantQuestionIntent = { intent: 'where_is_event' };
+
+    const result = await resolver.resolveIntentEvents(
+      whereIntent,
+      'Where is Open House?',
+      userEvents,
+      userEvents,
+    );
+
+    expect(result).toEqual(globalEvents);
+    expect(assistantDataService.loadPublicLookupEvents).toHaveBeenCalledWith(
+      userEvents,
+    );
+  });
+
+  it('keeps context events for non-lookup intent and neutral question', async () => {
+    const assistantDataService = {
+      loadPublicLookupEvents: jest.fn().mockResolvedValue(globalEvents),
+    };
+    const resolver = new AssistantScopeResolver(assistantDataService as never);
+
+    const listIntent: AssistantQuestionIntent = { intent: 'list_upcoming' };
+
+    const result = await resolver.resolveIntentEvents(
+      listIntent,
+      'List my upcoming events',
+      userEvents,
+      userEvents,
+    );
+
+    expect(result).toEqual(userEvents);
+    expect(assistantDataService.loadPublicLookupEvents).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/assistant/assistant-scope.resolver.ts
+++ b/backend/src/assistant/assistant-scope.resolver.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import {
+  isParticipantsQuestionText,
+  isWhereIsQuestionText,
+  shouldUseGlobalDateScopeQuestion,
+} from './assistant-text.helpers';
+import { AssistantDataService } from './assistant-data.service';
+import type {
+  AssistantEvent,
+  AssistantQuestionIntent,
+} from './assistant.types';
+
+@Injectable()
+export class AssistantScopeResolver {
+  constructor(private readonly assistantDataService: AssistantDataService) {}
+
+  async resolveContextEvents(
+    question: string,
+    userEvents: AssistantEvent[],
+  ): Promise<AssistantEvent[]> {
+    if (!shouldUseGlobalDateScopeQuestion(question)) {
+      return userEvents;
+    }
+
+    return this.assistantDataService.loadPublicLookupEvents(userEvents);
+  }
+
+  async resolveIntentEvents(
+    intent: AssistantQuestionIntent,
+    question: string,
+    userEvents: AssistantEvent[],
+    contextEvents: AssistantEvent[],
+  ): Promise<AssistantEvent[]> {
+    if (
+      intent.intent === 'where_is_event' ||
+      intent.intent === 'show_participants'
+    ) {
+      return this.assistantDataService.loadPublicLookupEvents(userEvents);
+    }
+
+    return this.resolveLookupEventsForQuestion(question, contextEvents);
+  }
+
+  async resolveLookupEventsForQuestion(
+    question: string,
+    contextEvents: AssistantEvent[],
+  ): Promise<AssistantEvent[]> {
+    const shouldUseGlobalLookup =
+      isWhereIsQuestionText(question) || isParticipantsQuestionText(question);
+
+    if (!shouldUseGlobalLookup) {
+      return contextEvents;
+    }
+
+    return this.assistantDataService.loadPublicLookupEvents(contextEvents);
+  }
+}

--- a/backend/src/assistant/assistant.module.ts
+++ b/backend/src/assistant/assistant.module.ts
@@ -5,10 +5,19 @@ import { Participant } from '../participants/entities/participant.entity';
 import { AssistantController } from './assistant.controller';
 import { AssistantService } from './assistant.service';
 import { AssistantLlmService } from './assistant-llm.service';
+import { AssistantDataService } from './assistant-data.service';
+import { AssistantScopeResolver } from './assistant-scope.resolver';
+import { AssistantFallbackResolver } from './assistant-fallback.resolver';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Event, Participant])],
   controllers: [AssistantController],
-  providers: [AssistantService, AssistantLlmService],
+  providers: [
+    AssistantService,
+    AssistantLlmService,
+    AssistantDataService,
+    AssistantScopeResolver,
+    AssistantFallbackResolver,
+  ],
 })
 export class AssistantModule {}

--- a/backend/src/assistant/assistant.service.spec.ts
+++ b/backend/src/assistant/assistant.service.spec.ts
@@ -5,6 +5,9 @@ import {
   AssistantLlmService,
   ASSISTANT_FALLBACK_MESSAGE,
 } from './assistant-llm.service';
+import { AssistantDataService } from './assistant-data.service';
+import { AssistantScopeResolver } from './assistant-scope.resolver';
+import { AssistantFallbackResolver } from './assistant-fallback.resolver';
 import { EventVisibility } from '../events/entities/event.entity';
 import { Event } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
@@ -57,6 +60,9 @@ describe('AssistantService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AssistantService,
+        AssistantDataService,
+        AssistantScopeResolver,
+        AssistantFallbackResolver,
         {
           provide: getRepositoryToken(Event),
           useValue: eventsRepository,

--- a/backend/src/assistant/assistant.service.ts
+++ b/backend/src/assistant/assistant.service.ts
@@ -1,44 +1,24 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import {
-  Event as EventEntity,
-  EventVisibility,
-} from '../events/entities/event.entity';
-import { Participant } from '../participants/entities/participant.entity';
-import { mergeAndSortCalendarEvents } from '../events/events.service.helpers';
-import {
-  answerFromIntent,
-  answerFromRules,
-  answerParticipantsFromQuestion,
-  answerWhereIsFromQuestion,
-} from './assistant-answer.helpers';
+import { answerFromIntent, answerFromRules } from './assistant-answer.helpers';
 import {
   AssistantLlmService,
   ASSISTANT_FALLBACK_MESSAGE,
-  type AssistantContextSnapshot,
 } from './assistant-llm.service';
-import {
-  isParticipantsQuestionText,
-  isWhereIsQuestionText,
-  shouldUseDateFallbackQuestion,
-  shouldUseGlobalDateScopeQuestion,
-} from './assistant-text.helpers';
-import type {
-  AssistantEvent,
-  AssistantQuestionIntent,
-} from './assistant.types';
+import { isParticipantsQuestionText } from './assistant-text.helpers';
+import type { AssistantQuestionIntent } from './assistant.types';
+import { AssistantDataService } from './assistant-data.service';
+import { AssistantScopeResolver } from './assistant-scope.resolver';
+import { AssistantFallbackResolver } from './assistant-fallback.resolver';
 
 @Injectable()
 export class AssistantService {
   private readonly logger = new Logger(AssistantService.name);
 
   constructor(
-    @InjectRepository(EventEntity)
-    private readonly eventsRepository: Repository<EventEntity>,
-    @InjectRepository(Participant)
-    private readonly participantsRepository: Repository<Participant>,
     private readonly assistantLlmService: AssistantLlmService,
+    private readonly assistantDataService: AssistantDataService,
+    private readonly assistantScopeResolver: AssistantScopeResolver,
+    private readonly assistantFallbackResolver: AssistantFallbackResolver,
   ) {}
 
   async answerQuestion(
@@ -46,10 +26,10 @@ export class AssistantService {
     userId: string,
   ): Promise<{ answer: string }> {
     const normalizedQuestion = question.trim();
-    const events = await this.loadUserEvents(userId);
-    const scopedEvents = await this.resolveEventsForQuestionScope(
-      question,
-      events,
+    const userEvents = await this.assistantDataService.loadUserEvents(userId);
+    const scopedEvents = await this.assistantScopeResolver.resolveContextEvents(
+      normalizedQuestion,
+      userEvents,
     );
     const now = new Date();
     const shouldQueryLlm = Boolean(process.env.AI_API_KEY?.trim());
@@ -60,7 +40,11 @@ export class AssistantService {
 
     // Deterministic rules are the fallback path when AI is not configured.
     if (!shouldQueryLlm) {
-      const localAnswer = answerFromRules(question, scopedEvents, now);
+      const localAnswer = answerFromRules(
+        normalizedQuestion,
+        scopedEvents,
+        now,
+      );
 
       if (localAnswer) {
         this.trace('Assistant response source: local-rules (no AI_API_KEY)');
@@ -73,118 +57,85 @@ export class AssistantService {
       return { answer: ASSISTANT_FALLBACK_MESSAGE };
     }
 
-    const snapshot = this.buildSnapshot(
+    const snapshot = this.assistantDataService.buildSnapshot(
       scopedEvents,
       now,
       userId,
-      isParticipantsQuestionText(question),
+      isParticipantsQuestionText(normalizedQuestion),
     );
 
-    const intent = await this.classifyQuestion(question, snapshot);
+    const intent = await this.classifyQuestion(normalizedQuestion, snapshot);
 
     // If the model cannot classify confidently, fall back to rule-based resolvers.
     if (!intent || intent.intent === 'fallback') {
-      const lookupEvents = await this.resolveLookupEventsForQuestion(
-        question,
-        scopedEvents,
-      );
-      const fallbackResolution = this.resolveFallbackAnswer(
-        question,
-        lookupEvents,
-        now,
-      );
-
-      if (fallbackResolution.answer) {
-        this.trace(`Assistant response source: ${fallbackResolution.source}`);
-        return { answer: fallbackResolution.answer };
-      }
-
-      this.trace('Assistant response source: fallback (llm unclear intent)');
-      return { answer: ASSISTANT_FALLBACK_MESSAGE };
-    }
-
-    if (
-      intent.intent === 'where_is_event' ||
-      intent.intent === 'show_participants'
-    ) {
-      const lookupEvents = await this.loadWhereIsLookupEvents(events);
-      const lookupAnswer = answerFromIntent(
-        intent,
-        lookupEvents,
-        now,
-        userId,
-        question,
-      );
-
-      if (!lookupAnswer) {
-        const fallbackResolution = this.resolveFallbackAnswer(
-          question,
-          lookupEvents,
-          now,
+      const fallbackEvents =
+        await this.assistantScopeResolver.resolveLookupEventsForQuestion(
+          normalizedQuestion,
+          scopedEvents,
         );
 
-        if (fallbackResolution.answer) {
-          this.trace(`Assistant response source: ${fallbackResolution.source}`);
-          return { answer: fallbackResolution.answer };
-        }
-
-        this.trace('Assistant response source: fallback (intent unsupported)');
-        return { answer: ASSISTANT_FALLBACK_MESSAGE };
-      }
-
-      this.trace(`Assistant response source: llm-intent (${intent.intent})`);
-      return { answer: lookupAnswer };
+      return this.resolveFallbackResponse(
+        normalizedQuestion,
+        fallbackEvents,
+        now,
+        'fallback (llm unclear intent)',
+      );
     }
+
+    const intentEvents = await this.assistantScopeResolver.resolveIntentEvents(
+      intent,
+      normalizedQuestion,
+      userEvents,
+      scopedEvents,
+    );
 
     const answer = answerFromIntent(
       intent,
-      scopedEvents,
+      intentEvents,
       now,
       userId,
-      question,
+      normalizedQuestion,
     );
 
     if (!answer) {
-      const lookupEvents = await this.resolveLookupEventsForQuestion(
-        question,
-        scopedEvents,
-      );
-      const fallbackResolution = this.resolveFallbackAnswer(
-        question,
-        lookupEvents,
+      return this.resolveFallbackResponse(
+        normalizedQuestion,
+        intentEvents,
         now,
+        'fallback (intent unsupported)',
       );
-
-      if (fallbackResolution.answer) {
-        this.trace(`Assistant response source: ${fallbackResolution.source}`);
-        return { answer: fallbackResolution.answer };
-      }
-
-      this.trace('Assistant response source: fallback (intent unsupported)');
-      return { answer: ASSISTANT_FALLBACK_MESSAGE };
     }
 
     this.trace(`Assistant response source: llm-intent (${intent.intent})`);
     return { answer };
   }
 
-  private async resolveEventsForQuestionScope(
-    question: string,
-    userEvents: AssistantEvent[],
-  ): Promise<AssistantEvent[]> {
-    // Date-oriented global queries may need public events outside the user's own list.
-    if (!shouldUseGlobalDateScopeQuestion(question)) {
-      return userEvents;
-    }
-
-    return this.loadWhereIsLookupEvents(userEvents);
-  }
-
   private async classifyQuestion(
     question: string,
-    snapshot: AssistantContextSnapshot,
+    snapshot: Parameters<AssistantLlmService['classifyQuestion']>[1],
   ): Promise<AssistantQuestionIntent | null> {
     return this.assistantLlmService.classifyQuestion(question, snapshot);
+  }
+
+  private resolveFallbackResponse(
+    question: string,
+    events: Parameters<AssistantFallbackResolver['resolve']>[1],
+    now: Date,
+    terminalFallbackLogMessage: string,
+  ): { answer: string } {
+    const fallbackResolution = this.assistantFallbackResolver.resolve(
+      question,
+      events,
+      now,
+    );
+
+    if (fallbackResolution.answer) {
+      this.trace(`Assistant response source: ${fallbackResolution.source}`);
+      return { answer: fallbackResolution.answer };
+    }
+
+    this.trace(`Assistant response source: ${terminalFallbackLogMessage}`);
+    return { answer: ASSISTANT_FALLBACK_MESSAGE };
   }
 
   private trace(message: string): void {
@@ -193,201 +144,5 @@ export class AssistantService {
     }
 
     this.logger.debug(message);
-  }
-
-  private async loadUserEvents(userId: string): Promise<AssistantEvent[]> {
-    // Read organizer and participant views in parallel, then merge unique events.
-    const [organizedEvents, participantRows] = await Promise.all([
-      this.eventsRepository.find({
-        where: { organizerId: userId },
-        relations: ['tags', 'participants', 'participants.user'],
-      }),
-      this.participantsRepository.find({
-        where: { userId },
-        relations: [
-          'event',
-          'event.tags',
-          'event.participants',
-          'event.participants.user',
-        ],
-      }),
-    ]);
-
-    const mergedEvents = mergeAndSortCalendarEvents(
-      organizedEvents,
-      participantRows,
-    );
-
-    this.trace(`DB response: loaded ${mergedEvents.length} events`);
-
-    return this.toAssistantEvents(mergedEvents);
-  }
-
-  private toAssistantEvents(events: EventEntity[]): AssistantEvent[] {
-    return events.map((event) => {
-      // TypeORM relation typing can be narrower than runtime-loaded relations.
-      const e = event as EventEntity & {
-        tags?: Array<{ name: string }>;
-        participants?: Array<{
-          userId: string;
-          user?: { name?: string | null; email?: string | null };
-        }>;
-      };
-
-      return {
-        id: event.id,
-        title: event.title,
-        eventDate: new Date(event.eventDate),
-        visibility: event.visibility,
-        location: event.location,
-        organizerId: event.organizerId,
-        tags: (e.tags ?? []).map((tag) => tag.name),
-        participantIds: (e.participants ?? []).map((p) => p.userId),
-        participantLabels: (e.participants ?? []).map((p) => {
-          const name = p.user?.name?.trim();
-
-          if (name) {
-            return name;
-          }
-
-          return p.userId;
-        }),
-      };
-    });
-  }
-
-  private async loadWhereIsLookupEvents(
-    userEvents: AssistantEvent[],
-  ): Promise<AssistantEvent[]> {
-    const publicEvents = await this.eventsRepository.find({
-      where: { visibility: EventVisibility.PUBLIC },
-      relations: ['tags', 'participants', 'participants.user'],
-    });
-
-    const mappedPublicEvents = this.toAssistantEvents(publicEvents);
-    const byId = new Map<string, AssistantEvent>();
-
-    userEvents.forEach((event) => byId.set(event.id, event));
-    mappedPublicEvents.forEach((event) => {
-      if (!byId.has(event.id)) {
-        byId.set(event.id, event);
-      }
-    });
-
-    return [...byId.values()];
-  }
-
-  private async resolveLookupEventsForQuestion(
-    question: string,
-    userEvents: AssistantEvent[],
-  ): Promise<AssistantEvent[]> {
-    const shouldUseGlobalLookup =
-      isWhereIsQuestionText(question) || isParticipantsQuestionText(question);
-
-    if (!shouldUseGlobalLookup) {
-      return userEvents;
-    }
-
-    return this.loadWhereIsLookupEvents(userEvents);
-  }
-
-  private resolveFallbackAnswer(
-    question: string,
-    events: AssistantEvent[],
-    now: Date,
-  ): {
-    source:
-      | 'heuristic-participants'
-      | 'heuristic-where-is'
-      | 'heuristic-fallback'
-      | 'local-rules-fallback';
-    answer: string | null;
-  } {
-    const participantsAnswer = answerParticipantsFromQuestion(question, events);
-
-    if (participantsAnswer) {
-      return {
-        source: 'heuristic-participants',
-        answer: participantsAnswer,
-      };
-    }
-
-    const locationAnswer = answerWhereIsFromQuestion(question, events);
-
-    if (locationAnswer) {
-      return {
-        source: 'heuristic-where-is',
-        answer: locationAnswer,
-      };
-    }
-
-    if (shouldUseDateFallbackQuestion(question)) {
-      const localFallbackAnswer = answerFromRules(question, events, now);
-
-      if (localFallbackAnswer) {
-        return {
-          source: 'local-rules-fallback',
-          answer: localFallbackAnswer,
-        };
-      }
-    }
-
-    return {
-      source: 'heuristic-fallback',
-      answer: null,
-    };
-  }
-
-  private buildSnapshot(
-    events: AssistantEvent[],
-    now: Date,
-    userId: string,
-    includeParticipantIdentifiers: boolean,
-  ): AssistantContextSnapshot {
-    const sortedDates = events
-      .map((event) => event.eventDate)
-      .sort((first, second) => first.getTime() - second.getTime());
-
-    const tags = [
-      ...new Set(
-        events.flatMap((event) => event.tags).map((tag) => tag.toLowerCase()),
-      ),
-    ].sort();
-
-    return {
-      currentUserId: userId,
-      generatedAt: now.toISOString(),
-      dateWindow: {
-        earliestEventDate: sortedDates[0]?.toISOString() ?? null,
-        latestEventDate: sortedDates.at(-1)?.toISOString() ?? null,
-      },
-      eventCount: events.length,
-      tags,
-      events: events.map((event) => {
-        const eventSnapshot = {
-          title: event.title,
-          eventDate: event.eventDate.toISOString(),
-          visibility: event.visibility,
-          relationToUser:
-            event.organizerId === userId
-              ? ('organizer' as const)
-              : event.participantIds.includes(userId)
-                ? ('participant' as const)
-                : ('unrelated' as const),
-          location: event.location,
-          tags: event.tags,
-          participantCount: event.participantIds.length,
-        };
-
-        if (includeParticipantIdentifiers) {
-          return {
-            ...eventSnapshot,
-            participantIds: event.participantIds,
-          };
-        }
-
-        return eventSnapshot;
-      }),
-    };
   }
 }


### PR DESCRIPTION
### What changed

- Split assistant workflow into focused backend layers:
- data and context loading
- scope resolution for personal vs global lookups
- transparent fallback resolution
- Kept AssistantService as a thin orchestrator only:
- classify question
- build context
- resolve scope
- execute intent
- resolve fallback
- Added focused tests for scope resolver and fallback resolver.
- Updated assistant module wiring and assistant service tests for new dependencies.
### Why

- Assistant logic was previously mixed in one large service, which made ownership and testability unclear.
- Clear responsibility boundaries improve readability, simplify maintenance, and reduce regression risk during future changes.
### Validation

- Ran assistant module tests via npm test -- assistant.
- Result: 63/63 tests passed, 8/8 test suites passed.
- Ran full backend test suite via npm test.
- Result: 119/119 tests passed, 18/18 test suites passed.

### Risks/Notes

- Main risk area is edge-case prompts around scope and fallback behavior.
- Mitigation applied:
- preserved external behavior
- added targeted tests around scope and fallback decision paths
- fixed fallback lookup scope for where and participants queries in fallback-intent flow.
Close #39 