### PR TITLE
refactor(frontend): make routing explicit and centralized

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,48 +1,7 @@
-import { Navigate, Route, Routes } from "react-router-dom";
-import { MainLayout } from "./components/layout/MainLayout";
-import { ProtectedRoute } from "./components/routing/ProtectedRoute";
-import { CreateEventPage } from "./pages/CreateEventPage";
-import { EventDetailsPage } from "./pages/EventDetailsPage";
-import { EventsPage } from "./pages/EventsPage";
-import { LoginPage } from "./pages/LoginPage";
-import { MyEventsPage } from "./pages/MyEventsPage";
-import { RegisterPage } from "./pages/RegisterPage";
+import { AppRouterProvider } from "./app/router";
 
 function App() {
-  return (
-    <Routes>
-      {/* Public auth screens */}
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/register" element={<RegisterPage />} />
-
-      <Route element={<MainLayout />}>
-        {/* Main app pages */}
-        <Route path="/" element={<Navigate to="/events" replace />} />
-        <Route path="/events" element={<EventsPage />} />
-        <Route path="/events/:id" element={<EventDetailsPage />} />
-
-        {/* Auth-required pages */}
-        <Route
-          path="/events/create"
-          element={
-            <ProtectedRoute>
-              <CreateEventPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/my-events"
-          element={
-            <ProtectedRoute>
-              <MyEventsPage />
-            </ProtectedRoute>
-          }
-        />
-      </Route>
-
-      <Route path="*" element={<Navigate to="/events" replace />} />
-    </Routes>
-  );
+  return <AppRouterProvider />;
 }
 
 export default App;

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,0 +1,68 @@
+import {
+  Navigate,
+  createBrowserRouter,
+  RouterProvider,
+} from "react-router-dom";
+import { MainLayout } from "../components/layout/MainLayout";
+import { ProtectedRoute } from "../components/routing/ProtectedRoute";
+import { CreateEventPage } from "../pages/CreateEventPage";
+import { EventDetailsPage } from "../pages/EventDetailsPage";
+import { EventsPage } from "../pages/EventsPage";
+import { LoginPage } from "../pages/LoginPage";
+import { MyEventsPage } from "../pages/MyEventsPage";
+import { RegisterPage } from "../pages/RegisterPage";
+import { APP_ROUTES } from "./routes";
+
+const appRoutes = [
+  {
+    path: APP_ROUTES.login,
+    element: <LoginPage />,
+  },
+  {
+    path: APP_ROUTES.register,
+    element: <RegisterPage />,
+  },
+  {
+    element: <MainLayout />,
+    children: [
+      {
+        path: APP_ROUTES.root,
+        element: <Navigate to={APP_ROUTES.events} replace />,
+      },
+      {
+        path: APP_ROUTES.events,
+        element: <EventsPage />,
+      },
+      {
+        path: APP_ROUTES.eventDetails,
+        element: <EventDetailsPage />,
+      },
+      {
+        path: APP_ROUTES.createEvent,
+        element: (
+          <ProtectedRoute>
+            <CreateEventPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: APP_ROUTES.myEvents,
+        element: (
+          <ProtectedRoute>
+            <MyEventsPage />
+          </ProtectedRoute>
+        ),
+      },
+    ],
+  },
+  {
+    path: APP_ROUTES.wildcard,
+    element: <Navigate to={APP_ROUTES.events} replace />,
+  },
+];
+
+const appRouter = createBrowserRouter(appRoutes);
+
+export const AppRouterProvider = () => {
+  return <RouterProvider router={appRouter} />;
+};

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -1,0 +1,10 @@
+export const APP_ROUTES = {
+  root: "/",
+  events: "/events",
+  eventDetails: "/events/:id",
+  createEvent: "/events/create",
+  myEvents: "/my-events",
+  login: "/login",
+  register: "/register",
+  wildcard: "*",
+} as const;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
-import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import { store } from "./app/store";
@@ -9,9 +8,7 @@ import { store } from "./app/store";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <Provider store={store}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <App />
     </Provider>
   </StrictMode>,
 );


### PR DESCRIPTION
What ### changed

- Moved route declarations into dedicated app-level routing modules:
- routes.ts for route constants
- router.tsx for centralized route wiring
- Simplified root app component:
- App.tsx now only renders router provider
- Removed BrowserRouter wrapping from main.tsx since routing is now managed centrally via app router.

### Why

- Previous routing setup was spread across root-level composition and route wiring, which is harder to scale as pages grow.
- Centralized app-level routing improves discoverability, maintainability, and makes future route changes safer.

### Validation

- Ran routing-related tests:
- npm run test:run -- src/components/routing/ProtectedRoute.test.tsx src/pages/LoginPage.test.tsx
- Result: 2/2 tests passed
- Ran full frontend suite:
- npm run test:run
- Result: 10/10 test files passed, 41/41 tests passed

### Risks/Notes

1. Risk: broken imports or route mapping after moving route declarations.
2. Mitigation: migration was done in small steps with repeated test verification and final full-suite run.
3. No behavior changes expected; refactor is structural.

Close #40 