### PR TITLE
docs(frontend): sync architecture docs with implemented refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ The project is split into a React frontend and a NestJS backend.
 The frontend follows a page + feature + shared-components structure.
 
 - `pages/` contains route-level containers such as `EventsPage`, `EventDetailsPage`, `CreateEventPage`, and `MyEventsPage`
-- `features/` contains domain logic such as Redux slices and custom hooks
-- `components/` contains reusable UI and page-specific presentational components
-- `shared/` contains common utilities such as API helpers, navigation helpers, validation helpers, and styling helpers
+- `features/` contains feature-owned `model`, `ui`, `lib`, and `api` modules
+- `components/` contains reusable cross-feature UI blocks (for example generic UI controls and assistant panel)
+- `shared/` contains only cross-feature primitives (API client and generic utility helpers)
 
 State management is intentionally split:
 
@@ -189,7 +189,7 @@ Larger pages are intentionally decomposed by responsibility.
 
 Examples:
 
-- `EventDetailsPage` coordinates state, while detail summary, actions, edit form, and delete modal are separate components
+- `EventDetailsPage` coordinates state, while detail summary and edit form are split into focused feature components
 - `MyEventsPage` coordinates calendar state, while week header, grid rendering, view toggle, and month navigation are separate components
 
 ### Key Tradeoffs

--- a/docs/frontend-state.md
+++ b/docs/frontend-state.md
@@ -34,5 +34,5 @@ This project intentionally uses both Redux Toolkit and Zustand.
 
 - Redux store setup: `frontend/src/app/store.ts`
 - Redux hooks: `frontend/src/app/hooks.ts`
-- Zustand assistant UI store: `frontend/src/features/events/assistantUiStore.ts`
-- Redux events domain slice: `frontend/src/features/events/eventsSlice.ts`
+- Zustand assistant UI store: `frontend/src/features/events/model/assistantUiStore.ts`
+- Redux events domain slice: `frontend/src/features/events/model/eventsSlice.ts`

--- a/docs/refactor-roadmap-feedback-2026-03-30.md
+++ b/docs/refactor-roadmap-feedback-2026-03-30.md
@@ -44,9 +44,9 @@ Frontend:
 - frontend/src/App.tsx
 - frontend/src/components/\*\*
 - frontend/src/features/events/\*\*
-- frontend/src/shared/api.ts
-- frontend/src/shared/navigation.ts
-- frontend/src/shared/eventValidation.ts
+- frontend/src/shared/api/client.ts
+- frontend/src/shared/lib/navigation.ts
+- frontend/src/features/events/lib/eventValidation.ts
 
 ## Фази
 
@@ -114,15 +114,15 @@ Frontend:
 
 План змін (мінімально інвазивно):
 
-1. Створити модулі:
+1. Розділити відповідальність на 2 ключові зони:
 
 - backend/src/assistant/assistant-data.service.ts
-- backend/src/assistant/assistant-scope.resolver.ts
-- backend/src/assistant/assistant-fallback.resolver.ts
+- backend/src/assistant/assistant.service.ts (оркестрація + прозорий fallback)
+- backend/src/assistant/assistant-llm.service.ts (класифікація через LLM)
 
 Примітка:
 
-- Допускаються еквівалентні назви (`*.repository.ts`, `resolvers/*`) за умови, що межі відповідальності збережені: data/context, scope, fallback.
+- Допускаються еквівалентні назви (`*.repository.ts`) за умови, що межі відповідальності збережені: data/context і llm-orchestration.
 
 2. Залишити в AssistantService лише сценарій:
 
@@ -149,7 +149,7 @@ Frontend:
 Файли:
 
 - frontend/src/App.tsx
-- frontend/src/shared/navigation.ts
+- frontend/src/shared/lib/navigation.ts
 
 План змін:
 

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -43,9 +43,8 @@ Current examples include:
 - `frontend/src/components/ui/DatePickerInput.stories.tsx`
 - `frontend/src/components/ui/VisibilityFieldset.stories.tsx`
 - `frontend/src/components/assistant/AssistantPanel.stories.tsx`
-- `frontend/src/components/event-details/EventCard.stories.tsx`
-- `frontend/src/components/event-details/DeleteConfirmModal.stories.tsx`
-- `frontend/src/components/event-form/EventTagsField.stories.tsx`
+- `frontend/src/features/events/ui/event-details/EventCard.stories.tsx`
+- `frontend/src/features/events/ui/event-form/EventTagsField.stories.tsx`
 
 ## Troubleshooting
 

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -125,18 +125,18 @@ Priority: Could
 
 Story-to-module mapping (frontend and backend ownership):
 
-| Story | Frontend scope                                                                              | Backend scope                                                                                                            |
-| ----- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| US-01 | `frontend/src/pages/EventsPage*`, `frontend/src/features/events/*`                          | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`                                        |
-| US-02 | `frontend/src/pages/EventDetailsPage*`                                                      | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/auth/auth.middleware.ts` |
-| US-03 | `frontend/src/features/auth/*`, auth pages/components                                       | `backend/src/auth/*`, `backend/src/users/*`                                                                              |
-| US-04 | event actions/components in `frontend/src/components/` and `frontend/src/features/events/*` | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/participants/*`          |
-| US-05 | `frontend/src/pages/MyEventsPage*`, calendar components/hooks                               | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`                                        |
-| US-06 | `frontend/src/pages/CreateEventPage*`, create form components/hooks                         | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/events/dto/*`            |
-| US-07 | edit form/components in event details flow                                                  | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/events/dto/*`            |
-| US-08 | delete modal/action in event details flow                                                   | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`                                        |
-| US-09 | assistant panel/components and request flow in `frontend/src/features/assistant/*`          | `backend/src/assistant/*`                                                                                                |
-| US-10 | recent prompts persistence in assistant UI state                                            | `backend/src/assistant/*` (answer flow), local persistence on frontend                                                   |
+| Story | Frontend scope                                                                                                                  | Backend scope                                                                                                            |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| US-01 | `frontend/src/pages/EventsPage*`, `frontend/src/features/events/*`                                                              | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`                                        |
+| US-02 | `frontend/src/pages/EventDetailsPage*`                                                                                          | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/auth/auth.middleware.ts` |
+| US-03 | `frontend/src/features/auth/*`, auth pages/components                                                                           | `backend/src/auth/*`, `backend/src/users/*`                                                                              |
+| US-04 | event actions/components in `frontend/src/features/events/ui/*` and related model hooks                                         | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/participants/*`          |
+| US-05 | `frontend/src/pages/MyEventsPage*`, calendar components/hooks                                                                   | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`                                        |
+| US-06 | `frontend/src/pages/CreateEventPage*`, create form components/hooks                                                             | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/events/dto/*`            |
+| US-07 | edit form/components in event details flow                                                                                      | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`, `backend/src/events/dto/*`            |
+| US-08 | delete modal/action in event details flow                                                                                       | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`                                        |
+| US-09 | assistant panel/components and request flow in `frontend/src/components/assistant/*` and `frontend/src/features/events/model/*` | `backend/src/assistant/*`                                                                                                |
+| US-10 | recent prompts persistence in assistant UI state                                                                                | `backend/src/assistant/*` (answer flow), local persistence on frontend                                                   |
 
 ## Status Tracking
 


### PR DESCRIPTION
### What changed

- Updated root architecture docs to reflect current feature-first frontend structure and shared boundaries.
- Fixed outdated paths in frontend state documentation after events model relocation.
- Updated Storybook guide examples to current stories locations and removed deleted modal story reference.
- Updated user stories traceability mapping for current frontend module ownership.
- Aligned roadmap references with implemented file paths and assistant simplification approach.

### Why

- Keep documentation consistent with actual codebase after refactor phases.
- Reduce onboarding and maintenance friction caused by stale paths and outdated module descriptions.
- Preserve documentation as a reliable project contract.

### Validation

- Verified referenced paths against current repository structure.
- Confirmed outdated path references were removed from updated docs.

### Risks/Notes

- Docs-only change.
- No runtime behavior or API changes.