### PR TITLE
refactor(auth): migrate to cookie-based sessions with csrf protection

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import ormconfig from './ormconfig';
@@ -13,6 +14,7 @@ import { UsersModule } from './users/users.module';
 import { EventsModule } from './events/events.module';
 import { AuthMiddleware } from './auth/auth.middleware';
 import { AssistantModule } from './assistant/assistant.module';
+import { CsrfProtectionGuard } from './auth/csrf-protection.guard';
 
 @Module({
   imports: [
@@ -23,7 +25,14 @@ import { AssistantModule } from './assistant/assistant.module';
     AssistantModule,
   ],
   controllers: [AppController],
-  providers: [AppService, AuthMiddleware],
+  providers: [
+    AppService,
+    AuthMiddleware,
+    {
+      provide: APP_GUARD,
+      useClass: CsrfProtectionGuard,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/backend/src/auth/auth-cookie.helpers.ts
+++ b/backend/src/auth/auth-cookie.helpers.ts
@@ -1,0 +1,168 @@
+import { randomBytes } from 'crypto';
+import type { CookieOptions, Request, Response } from 'express';
+import { resolveJwtExpiresIn, resolveRefreshJwtExpiresIn } from './jwt.config';
+
+export const ACCESS_TOKEN_COOKIE_NAME = 'access_token';
+export const REFRESH_TOKEN_COOKIE_NAME = 'refresh_token';
+export const CSRF_TOKEN_COOKIE_NAME = 'csrf_token';
+export const CSRF_HEADER_NAME = 'x-csrf-token';
+
+const parseCookieHeader = (cookieHeader?: string): Record<string, string> => {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return cookieHeader
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .reduce<Record<string, string>>((cookies, part) => {
+      const separatorIndex = part.indexOf('=');
+
+      if (separatorIndex <= 0) {
+        return cookies;
+      }
+
+      const name = part.slice(0, separatorIndex).trim();
+      const value = part.slice(separatorIndex + 1).trim();
+
+      cookies[name] = decodeURIComponent(value);
+      return cookies;
+    }, {});
+};
+
+const resolveMaxAge = (value: string): number => {
+  const normalizedValue = value.trim().toLowerCase();
+
+  if (/^\d+$/.test(normalizedValue)) {
+    return Number(normalizedValue) * 1000;
+  }
+
+  const match = normalizedValue.match(/^(\d+)(ms|s|m|h|d)$/);
+
+  if (!match) {
+    throw new Error(`Unsupported cookie max-age value: ${value}`);
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2];
+  const multipliers: Record<string, number> = {
+    ms: 1,
+    s: 1000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+
+  return amount * multipliers[unit];
+};
+
+const getCookieOptions = (
+  maxAge: number,
+  overrides?: Partial<CookieOptions>,
+): CookieOptions => ({
+  path: '/',
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+  maxAge,
+  ...overrides,
+});
+
+export const parseRequestCookies = (request: Request): Record<string, string> =>
+  parseCookieHeader(request.headers.cookie);
+
+export const extractCookieValue = (
+  request: Request,
+  cookieName: string,
+): string | null => parseRequestCookies(request)[cookieName] ?? null;
+
+export const extractAccessTokenFromRequest = (
+  request: Request,
+): string | null => {
+  const accessToken = extractCookieValue(request, ACCESS_TOKEN_COOKIE_NAME);
+
+  if (accessToken) {
+    return accessToken;
+  }
+
+  const authorization = request.headers.authorization;
+
+  if (!authorization?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const bearerToken = authorization.slice(7).trim();
+  return bearerToken || null;
+};
+
+export const extractRefreshTokenFromRequest = (
+  request: Request,
+): string | null => extractCookieValue(request, REFRESH_TOKEN_COOKIE_NAME);
+
+export const extractCsrfTokenFromRequest = (request: Request): string | null =>
+  extractCookieValue(request, CSRF_TOKEN_COOKIE_NAME);
+
+export const extractCsrfHeaderFromRequest = (
+  request: Request,
+): string | null => {
+  const headerValue = request.headers[CSRF_HEADER_NAME];
+
+  if (Array.isArray(headerValue)) {
+    return headerValue[0] ?? null;
+  }
+
+  return typeof headerValue === 'string' ? headerValue : null;
+};
+
+export const hasSessionCookie = (request: Request): boolean => {
+  const cookies = parseRequestCookies(request);
+
+  return Boolean(
+    cookies[ACCESS_TOKEN_COOKIE_NAME] || cookies[REFRESH_TOKEN_COOKIE_NAME],
+  );
+};
+
+export const createCsrfToken = (): string => randomBytes(24).toString('hex');
+
+export const setAuthCookies = (
+  response: Response,
+  input: {
+    accessToken: string;
+    refreshToken: string;
+    csrfToken: string;
+  },
+): void => {
+  response.cookie(
+    ACCESS_TOKEN_COOKIE_NAME,
+    input.accessToken,
+    getCookieOptions(resolveMaxAge(resolveJwtExpiresIn()), {
+      httpOnly: true,
+    }),
+  );
+  response.cookie(
+    REFRESH_TOKEN_COOKIE_NAME,
+    input.refreshToken,
+    getCookieOptions(resolveMaxAge(resolveRefreshJwtExpiresIn()), {
+      httpOnly: true,
+    }),
+  );
+  response.cookie(
+    CSRF_TOKEN_COOKIE_NAME,
+    input.csrfToken,
+    getCookieOptions(resolveMaxAge(resolveRefreshJwtExpiresIn()), {
+      httpOnly: false,
+    }),
+  );
+};
+
+export const clearAuthCookies = (response: Response): void => {
+  const baseOptions = {
+    path: '/',
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production',
+  };
+
+  response.clearCookie(ACCESS_TOKEN_COOKIE_NAME, baseOptions);
+  response.clearCookie(REFRESH_TOKEN_COOKIE_NAME, baseOptions);
+  response.clearCookie(CSRF_TOKEN_COOKIE_NAME, baseOptions);
+};

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,6 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import type { Request, Response } from 'express';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+
+type MockResponse = {
+  cookie: jest.Mock;
+  clearCookie: jest.Mock;
+};
+
+const createResponse = (): MockResponse => ({
+  cookie: jest.fn(),
+  clearCookie: jest.fn(),
+});
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -59,16 +70,14 @@ describe('AuthController', () => {
       csrfToken: 'csrf-token',
     });
 
-    const response = {
-      cookie: jest.fn(),
-    } as any;
+    const response = createResponse();
 
     const dto = {
       email: 'user@example.com',
       password: 'password123',
     };
 
-    const result = await controller.login(dto, response);
+    const result = await controller.login(dto, response as unknown as Response);
 
     expect(authService.login).toHaveBeenCalledWith(dto);
     expect(response.cookie).toHaveBeenCalledTimes(3);
@@ -95,12 +104,13 @@ describe('AuthController', () => {
       headers: {
         cookie: 'refresh_token=refresh-token',
       },
-    } as any;
-    const response = {
-      cookie: jest.fn(),
-    } as any;
+    };
+    const response = createResponse();
 
-    const result = await controller.refresh(request, response);
+    const result = await controller.refresh(
+      request as unknown as Request,
+      response as unknown as Response,
+    );
 
     expect(authService.refreshSession).toHaveBeenCalledWith('refresh-token');
     expect(response.cookie).toHaveBeenCalledTimes(3);
@@ -113,11 +123,11 @@ describe('AuthController', () => {
   });
 
   it('logout clears auth cookies', () => {
-    const response = {
-      clearCookie: jest.fn(),
-    } as any;
+    const response = createResponse();
 
-    expect(controller.logout(response)).toEqual({ success: true });
+    expect(controller.logout(response as unknown as Response)).toEqual({
+      success: true,
+    });
     expect(response.clearCookie).toHaveBeenCalledTimes(3);
   });
 

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -4,12 +4,17 @@ import { AuthService } from './auth.service';
 
 describe('AuthController', () => {
   let controller: AuthController;
-  let authService: { register: jest.Mock; login: jest.Mock };
+  let authService: {
+    register: jest.Mock;
+    login: jest.Mock;
+    refreshSession: jest.Mock;
+  };
 
   beforeEach(async () => {
     authService = {
       register: jest.fn(),
       login: jest.fn(),
+      refreshSession: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -44,16 +49,76 @@ describe('AuthController', () => {
   });
 
   it('login delegates to authService.login', async () => {
-    authService.login.mockResolvedValue({ accessToken: 'token' });
+    authService.login.mockResolvedValue({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      csrfToken: 'csrf-token',
+    });
+
+    const response = {
+      cookie: jest.fn(),
+    } as any;
 
     const dto = {
       email: 'user@example.com',
       password: 'password123',
     };
 
-    await controller.login(dto);
+    const result = await controller.login(dto, response);
 
     expect(authService.login).toHaveBeenCalledWith(dto);
+    expect(response.cookie).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+    });
+  });
+
+  it('refresh delegates to authService.refreshSession', async () => {
+    authService.refreshSession.mockResolvedValue({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      csrfToken: 'csrf-token',
+    });
+
+    const request = {
+      headers: {
+        cookie: 'refresh_token=refresh-token',
+      },
+    } as any;
+    const response = {
+      cookie: jest.fn(),
+    } as any;
+
+    const result = await controller.refresh(request, response);
+
+    expect(authService.refreshSession).toHaveBeenCalledWith('refresh-token');
+    expect(response.cookie).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+    });
+  });
+
+  it('logout clears auth cookies', () => {
+    const response = {
+      clearCookie: jest.fn(),
+    } as any;
+
+    expect(controller.logout(response)).toEqual({ success: true });
+    expect(response.clearCookie).toHaveBeenCalledTimes(3);
   });
 
   it('me returns request.user payload', () => {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -5,27 +5,90 @@ import {
   HttpCode,
   Post,
   Req,
+  Res,
   UseGuards,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { ApiBearerAuth } from '@nestjs/swagger';
+import type { Request, Response } from 'express';
+import {
+  clearAuthCookies,
+  extractRefreshTokenFromRequest,
+  setAuthCookies,
+} from './auth-cookie.helpers';
+
+type AuthSessionResponse = {
+  user: { sub: string; email: string };
+  accessToken: string;
+  refreshToken: string;
+  csrfToken: string;
+};
+
+type AuthControllerServiceContract = {
+  register: AuthService['register'];
+  login: (loginDto: LoginDto) => Promise<AuthSessionResponse>;
+  refreshSession: (refreshToken: string) => Promise<AuthSessionResponse>;
+};
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  private getAuthService(): AuthControllerServiceContract {
+    return this.authService as unknown as AuthControllerServiceContract;
+  }
+
   @Post('register')
   register(@Body() registerDto: RegisterDto) {
-    return this.authService.register(registerDto);
+    return this.getAuthService().register(registerDto);
   }
 
   @Post('login')
   @HttpCode(200)
-  login(@Body() loginDto: LoginDto) {
-    return this.authService.login(loginDto);
+  async login(
+    @Body() loginDto: LoginDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const session = await this.getAuthService().login(loginDto);
+    setAuthCookies(response, session);
+
+    return {
+      user: session.user,
+    };
+  }
+
+  @Post('refresh')
+  @HttpCode(200)
+  async refresh(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const refreshToken = extractRefreshTokenFromRequest(request);
+
+    if (!refreshToken) {
+      throw new UnauthorizedException('Refresh token is missing.');
+    }
+
+    const session = await this.getAuthService().refreshSession(refreshToken);
+    setAuthCookies(response, session);
+
+    return {
+      user: session.user,
+    };
+  }
+
+  @Post('logout')
+  @HttpCode(200)
+  logout(@Res({ passthrough: true }) response: Response) {
+    clearAuthCookies(response);
+
+    return {
+      success: true,
+    };
   }
 
   @Get('me')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
   UnauthorizedException,
 } from '@nestjs/common';
-import { AuthService } from './auth.service';
+import { AuthService, type AuthSessionPayload } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
@@ -21,30 +21,13 @@ import {
   setAuthCookies,
 } from './auth-cookie.helpers';
 
-type AuthSessionResponse = {
-  user: { sub: string; email: string };
-  accessToken: string;
-  refreshToken: string;
-  csrfToken: string;
-};
-
-type AuthControllerServiceContract = {
-  register: AuthService['register'];
-  login: (loginDto: LoginDto) => Promise<AuthSessionResponse>;
-  refreshSession: (refreshToken: string) => Promise<AuthSessionResponse>;
-};
-
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  private getAuthService(): AuthControllerServiceContract {
-    return this.authService as unknown as AuthControllerServiceContract;
-  }
-
   @Post('register')
   register(@Body() registerDto: RegisterDto) {
-    return this.getAuthService().register(registerDto);
+    return this.authService.register(registerDto);
   }
 
   @Post('login')
@@ -52,8 +35,8 @@ export class AuthController {
   async login(
     @Body() loginDto: LoginDto,
     @Res({ passthrough: true }) response: Response,
-  ) {
-    const session = await this.getAuthService().login(loginDto);
+  ): Promise<{ user: { sub: string; email: string } }> {
+    const session: AuthSessionPayload = await this.authService.login(loginDto);
     setAuthCookies(response, session);
 
     return {
@@ -66,14 +49,15 @@ export class AuthController {
   async refresh(
     @Req() request: Request,
     @Res({ passthrough: true }) response: Response,
-  ) {
+  ): Promise<{ user: { sub: string; email: string } }> {
     const refreshToken = extractRefreshTokenFromRequest(request);
 
     if (!refreshToken) {
       throw new UnauthorizedException('Refresh token is missing.');
     }
 
-    const session = await this.getAuthService().refreshSession(refreshToken);
+    const session: AuthSessionPayload =
+      await this.authService.refreshSession(refreshToken);
     setAuthCookies(response, session);
 
     return {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
   UnauthorizedException,
 } from '@nestjs/common';
-import { AuthService, type AuthSessionPayload } from './auth.service';
+import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
@@ -21,9 +21,38 @@ import {
   setAuthCookies,
 } from './auth-cookie.helpers';
 
+type RegisterResponse = {
+  id: string;
+  email: string;
+  name: string | null;
+  createdAt: Date;
+};
+
+type SessionUser = {
+  sub: string;
+  email: string;
+};
+
+type SessionPayload = {
+  user: SessionUser;
+  accessToken: string;
+  refreshToken: string;
+  csrfToken: string;
+};
+
+type AuthControllerService = {
+  register: (registerDto: RegisterDto) => Promise<RegisterResponse>;
+  login: (loginDto: LoginDto) => Promise<SessionPayload>;
+  refreshSession: (refreshToken: string) => Promise<SessionPayload>;
+};
+
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  private readonly authService: AuthControllerService;
+
+  constructor(authService: AuthService) {
+    this.authService = authService;
+  }
 
   @Post('register')
   register(@Body() registerDto: RegisterDto) {
@@ -36,7 +65,7 @@ export class AuthController {
     @Body() loginDto: LoginDto,
     @Res({ passthrough: true }) response: Response,
   ): Promise<{ user: { sub: string; email: string } }> {
-    const session: AuthSessionPayload = await this.authService.login(loginDto);
+    const session: SessionPayload = await this.authService.login(loginDto);
     setAuthCookies(response, session);
 
     return {
@@ -56,7 +85,7 @@ export class AuthController {
       throw new UnauthorizedException('Refresh token is missing.');
     }
 
-    const session: AuthSessionPayload =
+    const session: SessionPayload =
       await this.authService.refreshSession(refreshToken);
     setAuthCookies(response, session);
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   HttpCode,
+  Inject,
   Post,
   Req,
   Res,
@@ -10,6 +11,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
+import type { AuthSessionPayload, SessionUser } from './auth.types';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
@@ -28,31 +30,18 @@ type RegisterResponse = {
   createdAt: Date;
 };
 
-type SessionUser = {
-  sub: string;
-  email: string;
-};
-
-type SessionPayload = {
-  user: SessionUser;
-  accessToken: string;
-  refreshToken: string;
-  csrfToken: string;
-};
-
 type AuthControllerService = {
   register: (registerDto: RegisterDto) => Promise<RegisterResponse>;
-  login: (loginDto: LoginDto) => Promise<SessionPayload>;
-  refreshSession: (refreshToken: string) => Promise<SessionPayload>;
+  login: (loginDto: LoginDto) => Promise<AuthSessionPayload>;
+  refreshSession: (refreshToken: string) => Promise<AuthSessionPayload>;
 };
 
 @Controller('auth')
 export class AuthController {
-  private readonly authService: AuthControllerService;
-
-  constructor(authService: AuthService) {
-    this.authService = authService;
-  }
+  constructor(
+    @Inject(AuthService)
+    private readonly authService: AuthControllerService,
+  ) {}
 
   @Post('register')
   register(@Body() registerDto: RegisterDto) {
@@ -64,8 +53,8 @@ export class AuthController {
   async login(
     @Body() loginDto: LoginDto,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<{ user: { sub: string; email: string } }> {
-    const session: SessionPayload = await this.authService.login(loginDto);
+  ): Promise<{ user: SessionUser }> {
+    const session: AuthSessionPayload = await this.authService.login(loginDto);
     setAuthCookies(response, session);
 
     return {
@@ -78,14 +67,14 @@ export class AuthController {
   async refresh(
     @Req() request: Request,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<{ user: { sub: string; email: string } }> {
+  ): Promise<{ user: SessionUser }> {
     const refreshToken = extractRefreshTokenFromRequest(request);
 
     if (!refreshToken) {
       throw new UnauthorizedException('Refresh token is missing.');
     }
 
-    const session: SessionPayload =
+    const session: AuthSessionPayload =
       await this.authService.refreshSession(refreshToken);
     setAuthCookies(response, session);
 

--- a/backend/src/auth/auth.middleware.ts
+++ b/backend/src/auth/auth.middleware.ts
@@ -1,6 +1,7 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { NextFunction, Request, Response } from 'express';
+import { extractAccessTokenFromRequest } from './auth-cookie.helpers';
 
 type RequestWithAuthToken = Request & {
   authToken?: string;
@@ -15,10 +16,9 @@ export class AuthMiddleware implements NestMiddleware {
   constructor(private readonly jwtService: JwtService) {}
 
   use(req: RequestWithAuthToken, _res: Response, next: NextFunction): void {
-    const authorization = req.headers.authorization;
+    const token = extractAccessTokenFromRequest(req);
 
-    if (authorization?.startsWith('Bearer ')) {
-      const token = authorization.slice(7).trim();
+    if (token) {
       req.authToken = token;
 
       try {

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -4,11 +4,10 @@ import { AuthController } from './auth.controller';
 import { UsersModule } from '../users/users.module';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-import type { StringValue } from 'ms';
 import { JwtStrategy } from './jwt.strategy';
-import { resolveJwtSecret } from './jwt.config';
+import { resolveJwtExpiresIn, resolveJwtSecret } from './jwt.config';
 
-const jwtExpiresIn = (process.env.JWT_EXPIRES_IN ?? '1h') as StringValue;
+const jwtExpiresIn = resolveJwtExpiresIn();
 const jwtSecret = resolveJwtSecret();
 
 @Module({

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -17,7 +17,7 @@ describe('AuthService', () => {
     findByEmailWithPassword: jest.Mock;
     createUser: jest.Mock;
   };
-  let jwtService: { signAsync: jest.Mock };
+  let jwtService: { signAsync: jest.Mock; verifyAsync: jest.Mock };
 
   beforeEach(async () => {
     usersService = {
@@ -28,6 +28,7 @@ describe('AuthService', () => {
 
     jwtService = {
       signAsync: jest.fn(),
+      verifyAsync: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -121,7 +122,7 @@ describe('AuthService', () => {
     expect(compare).toHaveBeenCalledWith('wrong-password', 'hashed-password');
   });
 
-  it('login returns bearer token for valid credentials', async () => {
+  it('login returns session payload for valid credentials', async () => {
     usersService.findByEmailWithPassword.mockResolvedValue({
       id: 'user-id',
       email: 'user@example.com',
@@ -129,20 +130,88 @@ describe('AuthService', () => {
     });
 
     (compare as jest.Mock).mockResolvedValue(true);
-    jwtService.signAsync.mockResolvedValue('jwt-token');
+    jwtService.signAsync
+      .mockResolvedValueOnce('access-token')
+      .mockResolvedValueOnce('refresh-token');
 
     const result = await service.login({
       email: 'user@example.com',
       password: 'password123',
     });
 
-    expect(jwtService.signAsync).toHaveBeenCalledWith({
+    expect(jwtService.signAsync).toHaveBeenNthCalledWith(1, {
       sub: 'user-id',
       email: 'user@example.com',
     });
+    expect(jwtService.signAsync).toHaveBeenNthCalledWith(
+      2,
+      {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+      expect.objectContaining({
+        secret: expect.any(String),
+        expiresIn: expect.any(String),
+      }),
+    );
     expect(result).toEqual({
-      accessToken: 'jwt-token',
-      tokenType: 'Bearer',
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      csrfToken: expect.any(String),
     });
+  });
+
+  it('refreshSession reissues tokens for valid refresh token', async () => {
+    jwtService.verifyAsync.mockResolvedValue({
+      sub: 'user-id',
+      email: 'user@example.com',
+    });
+    usersService.findByEmail.mockResolvedValue({
+      id: 'user-id',
+      email: 'user@example.com',
+    });
+    jwtService.signAsync
+      .mockResolvedValueOnce('access-token')
+      .mockResolvedValueOnce('refresh-token');
+
+    const result = await service.refreshSession('refresh-token');
+
+    expect(jwtService.verifyAsync).toHaveBeenCalledWith(
+      'refresh-token',
+      expect.objectContaining({ secret: expect.any(String) }),
+    );
+    expect(result).toEqual({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      csrfToken: expect.any(String),
+    });
+  });
+
+  it('refreshSession throws UnauthorizedException for invalid token', async () => {
+    jwtService.verifyAsync.mockRejectedValue(new Error('invalid token'));
+
+    await expect(service.refreshSession('bad-token')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('refreshSession throws UnauthorizedException when user is missing', async () => {
+    jwtService.verifyAsync.mockResolvedValue({
+      sub: 'user-id',
+      email: 'user@example.com',
+    });
+    usersService.findByEmail.mockResolvedValue(null);
+
+    await expect(
+      service.refreshSession('refresh-token'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -13,18 +13,9 @@ import {
   resolveRefreshJwtExpiresIn,
   resolveRefreshJwtSecret,
 } from './jwt.config';
+import type { AuthSessionPayload, SessionUser } from './auth.types';
 
-export type SessionUser = {
-  sub: string;
-  email: string;
-};
-
-export type AuthSessionPayload = {
-  user: SessionUser;
-  accessToken: string;
-  refreshToken: string;
-  csrfToken: string;
-};
+export type { AuthSessionPayload, SessionUser } from './auth.types';
 
 type RefreshTokenPayload = {
   sub: string;

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -8,6 +8,28 @@ import { UsersService } from '../users/users.service';
 import { RegisterDto } from './dto/register.dto';
 import { JwtService } from '@nestjs/jwt';
 import { LoginDto } from './dto/login.dto';
+import { createCsrfToken } from './auth-cookie.helpers';
+import {
+  resolveRefreshJwtExpiresIn,
+  resolveRefreshJwtSecret,
+} from './jwt.config';
+
+export type SessionUser = {
+  sub: string;
+  email: string;
+};
+
+export type AuthSessionPayload = {
+  user: SessionUser;
+  accessToken: string;
+  refreshToken: string;
+  csrfToken: string;
+};
+
+type RefreshTokenPayload = {
+  sub: string;
+  email: string;
+};
 
 @Injectable()
 export class AuthService {
@@ -44,10 +66,7 @@ export class AuthService {
     };
   }
 
-  async login(loginDto: LoginDto): Promise<{
-    accessToken: string;
-    tokenType: 'Bearer';
-  }> {
+  async login(loginDto: LoginDto): Promise<AuthSessionPayload> {
     const user = await this.usersService.findByEmailWithPassword(
       loginDto.email,
     );
@@ -63,15 +82,55 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials.');
     }
 
-    // Keep JWT payload minimal for downstream authorization checks.
-    const accessToken = await this.jwtService.signAsync({
+    return this.createSessionPayload({
       sub: user.id,
       email: user.email,
     });
+  }
+
+  async refreshSession(refreshToken: string): Promise<AuthSessionPayload> {
+    const payload = await this.verifyRefreshToken(refreshToken);
+    const existingUser = await this.usersService.findByEmail(payload.email);
+
+    if (!existingUser || existingUser.id !== payload.sub) {
+      throw new UnauthorizedException('Invalid session.');
+    }
+
+    return this.createSessionPayload({
+      sub: existingUser.id,
+      email: existingUser.email,
+    });
+  }
+
+  private async createSessionPayload(
+    user: SessionUser,
+  ): Promise<AuthSessionPayload> {
+    const accessToken = await this.jwtService.signAsync(user);
+    const refreshToken = await this.jwtService.signAsync(user, {
+      secret: resolveRefreshJwtSecret(),
+      expiresIn: resolveRefreshJwtExpiresIn(),
+    });
 
     return {
+      user,
       accessToken,
-      tokenType: 'Bearer',
+      refreshToken,
+      csrfToken: createCsrfToken(),
     };
+  }
+
+  private async verifyRefreshToken(
+    refreshToken: string,
+  ): Promise<RefreshTokenPayload> {
+    try {
+      return await this.jwtService.verifyAsync<RefreshTokenPayload>(
+        refreshToken,
+        {
+          secret: resolveRefreshJwtSecret(),
+        },
+      );
+    } catch {
+      throw new UnauthorizedException('Invalid session.');
+    }
   }
 }

--- a/backend/src/auth/auth.types.ts
+++ b/backend/src/auth/auth.types.ts
@@ -1,0 +1,11 @@
+export type SessionUser = {
+  sub: string;
+  email: string;
+};
+
+export type AuthSessionPayload = {
+  user: SessionUser;
+  accessToken: string;
+  refreshToken: string;
+  csrfToken: string;
+};

--- a/backend/src/auth/csrf-protection.guard.spec.ts
+++ b/backend/src/auth/csrf-protection.guard.spec.ts
@@ -1,0 +1,63 @@
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import type { Request } from 'express';
+import {
+  ACCESS_TOKEN_COOKIE_NAME,
+  CSRF_TOKEN_COOKIE_NAME,
+  CSRF_HEADER_NAME,
+} from './auth-cookie.helpers';
+import { CsrfProtectionGuard } from './csrf-protection.guard';
+
+const createExecutionContext = (request: Partial<Request>): ExecutionContext =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('CsrfProtectionGuard', () => {
+  const guard = new CsrfProtectionGuard();
+
+  it('allows safe HTTP methods', () => {
+    const context = createExecutionContext({
+      method: 'GET',
+      headers: {
+        cookie: `${ACCESS_TOKEN_COOKIE_NAME}=access-token`,
+      },
+    });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('bypasses CSRF check for unsafe methods without session cookies', () => {
+    const context = createExecutionContext({
+      method: 'POST',
+      headers: {},
+    });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('throws ForbiddenException when CSRF cookie and header do not match', () => {
+    const context = createExecutionContext({
+      method: 'PATCH',
+      headers: {
+        cookie: `${ACCESS_TOKEN_COOKIE_NAME}=access-token; ${CSRF_TOKEN_COOKIE_NAME}=cookie-token`,
+        [CSRF_HEADER_NAME]: 'header-token',
+      },
+    });
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it('allows unsafe methods when CSRF cookie and header match', () => {
+    const context = createExecutionContext({
+      method: 'DELETE',
+      headers: {
+        cookie: `${ACCESS_TOKEN_COOKIE_NAME}=access-token; ${CSRF_TOKEN_COOKIE_NAME}=same-token`,
+        [CSRF_HEADER_NAME]: 'same-token',
+      },
+    });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+});

--- a/backend/src/auth/csrf-protection.guard.ts
+++ b/backend/src/auth/csrf-protection.guard.ts
@@ -1,0 +1,38 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import {
+  extractCsrfHeaderFromRequest,
+  extractCsrfTokenFromRequest,
+  hasSessionCookie,
+} from './auth-cookie.helpers';
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+@Injectable()
+export class CsrfProtectionGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    if (SAFE_METHODS.has(request.method)) {
+      return true;
+    }
+
+    if (!hasSessionCookie(request)) {
+      return true;
+    }
+
+    const csrfCookie = extractCsrfTokenFromRequest(request);
+    const csrfHeader = extractCsrfHeaderFromRequest(request);
+
+    if (!csrfCookie || !csrfHeader || csrfCookie !== csrfHeader) {
+      throw new ForbiddenException('CSRF validation failed.');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/auth/jwt.config.ts
+++ b/backend/src/auth/jwt.config.ts
@@ -11,3 +11,19 @@ export const resolveJwtSecret = (): string => {
 
   return 'dev-jwt-secret';
 };
+
+export const resolveJwtExpiresIn = (): string =>
+  process.env.JWT_EXPIRES_IN?.trim() || '15m';
+
+export const resolveRefreshJwtSecret = (): string => {
+  const refreshJwtSecret = process.env.REFRESH_JWT_SECRET?.trim();
+
+  if (refreshJwtSecret) {
+    return refreshJwtSecret;
+  }
+
+  return resolveJwtSecret();
+};
+
+export const resolveRefreshJwtExpiresIn = (): string =>
+  process.env.REFRESH_JWT_EXPIRES_IN?.trim() || '7d';

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,6 +1,8 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import type { Request } from 'express';
+import { extractAccessTokenFromRequest } from './auth-cookie.helpers';
 import { resolveJwtSecret } from './jwt.config';
 
 type JwtPayload = {
@@ -12,7 +14,9 @@ type JwtPayload = {
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor() {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request: Request) => extractAccessTokenFromRequest(request),
+      ]),
       ignoreExpiration: false,
       secretOrKey: resolveJwtSecret(),
     });

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -7,16 +7,26 @@ import { AuthController } from '../src/auth/auth.controller';
 import { AuthService } from '../src/auth/auth.service';
 import { JwtStrategy } from '../src/auth/jwt.strategy';
 import { resolveJwtSecret } from '../src/auth/jwt.config';
+import {
+  ACCESS_TOKEN_COOKIE_NAME,
+  CSRF_TOKEN_COOKIE_NAME,
+  REFRESH_TOKEN_COOKIE_NAME,
+} from '../src/auth/auth-cookie.helpers';
 
 describe('AuthController (e2e)', () => {
   let app: INestApplication;
   let jwtService: JwtService;
-  let authService: { register: jest.Mock; login: jest.Mock };
+  let authService: {
+    register: jest.Mock;
+    login: jest.Mock;
+    refreshSession: jest.Mock;
+  };
 
   beforeAll(async () => {
     authService = {
       register: jest.fn(),
       login: jest.fn(),
+      refreshSession: jest.fn(),
     };
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -48,6 +58,7 @@ describe('AuthController (e2e)', () => {
   beforeEach(() => {
     authService.register.mockReset();
     authService.login.mockReset();
+    authService.refreshSession.mockReset();
   });
 
   it('/auth/me (GET) returns 401 without token', () => {
@@ -77,6 +88,27 @@ describe('AuthController (e2e)', () => {
     );
   });
 
+  it('/auth/me (GET) returns payload with valid access cookie', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const token = await jwtService.signAsync({
+      sub: 'user-id',
+      email: 'user@example.com',
+    });
+
+    const response = await request(httpServer)
+      .get('/auth/me')
+      .set('Cookie', [`${ACCESS_TOKEN_COOKIE_NAME}=${token}`])
+      .expect(200);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        sub: 'user-id',
+        email: 'user@example.com',
+      }),
+    );
+  });
+
   it('register -> login -> me happy-path', async () => {
     const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
 
@@ -93,8 +125,13 @@ describe('AuthController (e2e)', () => {
     });
 
     authService.login.mockResolvedValue({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
       accessToken: token,
-      tokenType: 'Bearer',
+      refreshToken: 'refresh-token',
+      csrfToken: 'csrf-token',
     });
 
     await request(httpServer)
@@ -106,7 +143,7 @@ describe('AuthController (e2e)', () => {
       })
       .expect(201);
 
-    await request(httpServer)
+    const loginResponse = await request(httpServer)
       .post('/auth/login')
       .send({
         email: 'user@example.com',
@@ -114,9 +151,23 @@ describe('AuthController (e2e)', () => {
       })
       .expect(200);
 
+    expect(loginResponse.body).toEqual({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+    });
+    expect(loginResponse.headers['set-cookie']).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`${ACCESS_TOKEN_COOKIE_NAME}=`),
+        expect.stringContaining(`${REFRESH_TOKEN_COOKIE_NAME}=`),
+        expect.stringContaining(`${CSRF_TOKEN_COOKIE_NAME}=`),
+      ]),
+    );
+
     const meResponse = await request(httpServer)
       .get('/auth/me')
-      .set('Authorization', `Bearer ${token}`)
+      .set('Cookie', [`${ACCESS_TOKEN_COOKIE_NAME}=${token}`])
       .expect(200);
 
     expect(authService.register).toHaveBeenCalledWith({
@@ -133,6 +184,59 @@ describe('AuthController (e2e)', () => {
         sub: 'user-id',
         email: 'user@example.com',
       }),
+    );
+  });
+
+  it('/auth/refresh (POST) rotates cookies and returns user', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    authService.refreshSession.mockResolvedValue({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+      csrfToken: 'next-csrf-token',
+    });
+
+    const response = await request(httpServer)
+      .post('/auth/refresh')
+      .set('Cookie', [`${REFRESH_TOKEN_COOKIE_NAME}=refresh-token`])
+      .expect(200);
+
+    expect(authService.refreshSession).toHaveBeenCalledWith('refresh-token');
+    expect(response.body).toEqual({
+      user: {
+        sub: 'user-id',
+        email: 'user@example.com',
+      },
+    });
+    expect(response.headers['set-cookie']).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          `${ACCESS_TOKEN_COOKIE_NAME}=next-access-token`,
+        ),
+        expect.stringContaining(
+          `${REFRESH_TOKEN_COOKIE_NAME}=next-refresh-token`,
+        ),
+        expect.stringContaining(`${CSRF_TOKEN_COOKIE_NAME}=next-csrf-token`),
+      ]),
+    );
+  });
+
+  it('/auth/logout (POST) clears auth cookies', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(httpServer).post('/auth/logout').expect(200);
+
+    expect(response.body).toEqual({ success: true });
+    expect(response.headers['set-cookie']).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`${ACCESS_TOKEN_COOKIE_NAME}=;`),
+        expect.stringContaining(`${REFRESH_TOKEN_COOKIE_NAME}=;`),
+        expect.stringContaining(`${CSRF_TOKEN_COOKIE_NAME}=;`),
+      ]),
     );
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
 import { AppRouterProvider } from "./app/router";
+import { useAppDispatch } from "./app/hooks";
+import { fetchSession } from "./features/auth/authSlice";
 
 function App() {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    void dispatch(fetchSession());
+  }, [dispatch]);
+
   return <AppRouterProvider />;
 }
 

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
+import { selectIsAuthenticated } from "../../features/auth/authSelectors";
 import { logoutUser } from "../../features/auth/authSlice";
 import { Button } from "../ui/Button";
 
@@ -7,9 +8,7 @@ export function MainLayout() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const location = useLocation();
-  const isAuthenticated = useAppSelector(
-    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
-  );
+  const isAuthenticated = useAppSelector(selectIsAuthenticated);
   const userEmail = useAppSelector((state) => state.auth.user?.email);
 
   const displayName = userEmail?.split("@")[0] || "User";

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,19 +1,21 @@
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
-import { logout } from "../../features/auth/authSlice";
+import { logoutUser } from "../../features/auth/authSlice";
 import { Button } from "../ui/Button";
 
 export function MainLayout() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const location = useLocation();
-  const token = useAppSelector((state) => state.auth.token);
+  const isAuthenticated = useAppSelector(
+    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
+  );
   const userEmail = useAppSelector((state) => state.auth.user?.email);
 
   const displayName = userEmail?.split("@")[0] || "User";
 
-  const handleLogout = () => {
-    dispatch(logout());
+  const handleLogout = async () => {
+    await dispatch(logoutUser());
     navigate("/");
   };
 
@@ -190,7 +192,7 @@ export function MainLayout() {
               </svg>
               Create Event
             </Link>
-            {token ? (
+            {isAuthenticated ? (
               <div className="ml-3 flex items-center gap-3 border-l border-slate-200 pl-6">
                 <span className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-100 text-indigo-600">
                   <svg
@@ -222,7 +224,7 @@ export function MainLayout() {
                 </span>
                 <Button
                   type="button"
-                  onClick={handleLogout}
+                  onClick={() => void handleLogout()}
                   aria-label="Logout"
                   className="inline-flex h-10 w-10 items-center justify-center rounded-md text-slate-700 hover:bg-slate-100"
                 >

--- a/frontend/src/components/routing/ProtectedRoute.tsx
+++ b/frontend/src/components/routing/ProtectedRoute.tsx
@@ -7,12 +7,21 @@ type ProtectedRouteProps = {
 };
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const token = useAppSelector((state) => state.auth.token);
+  const isAuthenticated = useAppSelector(
+    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
+  );
+  const isInitialized = useAppSelector(
+    (state) => state.auth.isInitialized ?? true,
+  );
   const location = useLocation();
   // Preserve full location so login can return user to the original target.
   const from = `${location.pathname}${location.search}${location.hash}`;
 
-  if (!token) {
+  if (!isInitialized) {
+    return null;
+  }
+
+  if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from }} />;
   }
 

--- a/frontend/src/components/routing/ProtectedRoute.tsx
+++ b/frontend/src/components/routing/ProtectedRoute.tsx
@@ -1,18 +1,18 @@
 import type { ReactNode } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useAppSelector } from "../../app/hooks";
+import {
+  selectIsAuthenticated,
+  selectIsInitialized,
+} from "../../features/auth/authSelectors";
 
 type ProtectedRouteProps = {
   children: ReactNode;
 };
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const isAuthenticated = useAppSelector(
-    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
-  );
-  const isInitialized = useAppSelector(
-    (state) => state.auth.isInitialized ?? true,
-  );
+  const isAuthenticated = useAppSelector(selectIsAuthenticated);
+  const isInitialized = useAppSelector(selectIsInitialized);
   const location = useLocation();
   // Preserve full location so login can return user to the original target.
   const from = `${location.pathname}${location.search}${location.hash}`;

--- a/frontend/src/features/auth/authSelectors.ts
+++ b/frontend/src/features/auth/authSelectors.ts
@@ -1,0 +1,7 @@
+import type { RootState } from "../../app/store";
+
+export const selectIsAuthenticated = (state: RootState): boolean =>
+  state.auth.isAuthenticated ?? Boolean(state.auth.token);
+
+export const selectIsInitialized = (state: RootState): boolean =>
+  state.auth.isInitialized ?? true;

--- a/frontend/src/features/auth/authSlice.test.ts
+++ b/frontend/src/features/auth/authSlice.test.ts
@@ -1,54 +1,51 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { authReducer, loginUser } from "./authSlice";
 
-const createTokenWithEmail = (email: string) => {
-  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
-  const payload = btoa(JSON.stringify({ email }))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
-
-  return `${header}.${payload}.signature`;
-};
-
 describe("authSlice", () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it("derives user email from JWT on login fulfilled", () => {
-    const token = createTokenWithEmail("normalized.user@example.com");
-
+  it("stores authenticated user from login payload", () => {
     const state = authReducer(
       undefined,
-      loginUser.fulfilled({ token }, "request-id", {
+      loginUser.fulfilled(
+        {
+          user: {
+            sub: "user-id",
+            email: "normalized.user@example.com",
+          },
+        },
+        "request-id",
+        {
+          email: "  RAW@Example.com  ",
+          password: "password",
+        },
+      ),
+    );
+
+    expect(state.token).toBeNull();
+    expect(state.user).toEqual({
+      sub: "user-id",
+      email: "normalized.user@example.com",
+    });
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.isInitialized).toBe(true);
+    expect(localStorage.getItem("accessToken")).toBeNull();
+  });
+
+  it("keeps user null when login payload has no user", () => {
+    const state = authReducer(
+      undefined,
+      loginUser.rejected(new Error("Unauthorized"), "request-id", {
         email: "  RAW@Example.com  ",
         password: "password",
       }),
     );
 
-    expect(state.token).toBe(token);
-    expect(state.user).toEqual({ email: "normalized.user@example.com" });
-    expect(localStorage.getItem("accessToken")).toBe(token);
-  });
-
-  it("sets user to null when JWT has no email claim", () => {
-    const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
-    const payload = btoa(JSON.stringify({ sub: "user-id" }));
-    const token = `${header}.${payload}.signature`;
-
-    const state = authReducer(
-      undefined,
-      loginUser.fulfilled({ token }, "request-id", {
-        email: "input@example.com",
-        password: "password",
-      }),
-    );
-
-    expect(state.token).toBe(token);
+    expect(state.token).toBeNull();
     expect(state.user).toBeNull();
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.isInitialized).toBe(true);
   });
 });

--- a/frontend/src/features/auth/authSlice.test.ts
+++ b/frontend/src/features/auth/authSlice.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { authReducer, loginUser } from "./authSlice";
+import { authReducer, loginUser, logoutUser } from "./authSlice";
 
 describe("authSlice", () => {
   beforeEach(() => {
@@ -47,5 +47,35 @@ describe("authSlice", () => {
     expect(state.user).toBeNull();
     expect(state.isAuthenticated).toBe(false);
     expect(state.isInitialized).toBe(true);
+  });
+
+  it("clears auth state when logout request fails", () => {
+    const authenticatedState = authReducer(
+      undefined,
+      loginUser.fulfilled(
+        {
+          user: {
+            sub: "user-id",
+            email: "normalized.user@example.com",
+          },
+        },
+        "login-request-id",
+        {
+          email: "RAW@Example.com",
+          password: "password",
+        },
+      ),
+    );
+
+    const state = authReducer(
+      authenticatedState,
+      logoutUser.rejected(new Error("Network error"), "logout-request-id"),
+    );
+
+    expect(state.token).toBeNull();
+    expect(state.user).toBeNull();
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.isInitialized).toBe(true);
+    expect(state.error).toBeNull();
   });
 });

--- a/frontend/src/features/auth/authSlice.test.ts
+++ b/frontend/src/features/auth/authSlice.test.ts
@@ -34,7 +34,7 @@ describe("authSlice", () => {
     expect(localStorage.getItem("accessToken")).toBeNull();
   });
 
-  it("keeps user null when login payload has no user", () => {
+  it("keeps user null when login is rejected as unauthorized", () => {
     const state = authReducer(
       undefined,
       loginUser.rejected(new Error("Unauthorized"), "request-id", {

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -2,12 +2,15 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { api } from "../../shared/api/client";
 
 type User = {
+  sub?: string;
   email: string;
 };
 
 type AuthState = {
   token: string | null;
   user: User | null;
+  isAuthenticated?: boolean;
+  isInitialized?: boolean;
   status: "idle" | "loading" | "failed";
   error: string | null;
 };
@@ -23,48 +26,11 @@ type RegisterPayload = {
   password: string;
 };
 
-const tokenFromStorage = localStorage.getItem("accessToken");
-
-const decodeBase64Url = (value: string) => {
-  const normalizedValue = value.replace(/-/g, "+").replace(/_/g, "/");
-  const paddingLength = (4 - (normalizedValue.length % 4)) % 4;
-  const paddedValue = normalizedValue.padEnd(
-    normalizedValue.length + paddingLength,
-    "=",
-  );
-
-  return atob(paddedValue);
-};
-
-const getUserFromToken = (token: string | null): User | null => {
-  if (!token) {
-    return null;
-  }
-
-  try {
-    const base64Payload = token.split(".")[1];
-
-    if (!base64Payload) {
-      return null;
-    }
-
-    const decoded = JSON.parse(decodeBase64Url(base64Payload)) as {
-      email?: string;
-    };
-
-    if (!decoded.email) {
-      return null;
-    }
-
-    return { email: decoded.email };
-  } catch {
-    return null;
-  }
-};
-
 const initialState: AuthState = {
-  token: tokenFromStorage,
-  user: getUserFromToken(tokenFromStorage),
+  token: null,
+  user: null,
+  isAuthenticated: false,
+  isInitialized: false,
   status: "idle",
   error: null,
 };
@@ -73,15 +39,21 @@ export const loginUser = createAsyncThunk(
   "auth/loginUser",
   async (payload: LoginPayload) => {
     const response = await api.post<{
-      accessToken: string;
-      tokenType: "Bearer";
+      user: User;
     }>("/auth/login", payload);
 
-    return {
-      token: response.data.accessToken,
-    };
+    return response.data;
   },
 );
+
+export const fetchSession = createAsyncThunk("auth/fetchSession", async () => {
+  const response = await api.get<User>("/auth/me");
+  return response.data;
+});
+
+export const logoutUser = createAsyncThunk("auth/logoutUser", async () => {
+  await api.post("/auth/logout");
+});
 
 export const registerUser = createAsyncThunk(
   "auth/registerUser",
@@ -94,13 +66,7 @@ export const registerUser = createAsyncThunk(
 const authSlice = createSlice({
   name: "auth",
   initialState,
-  reducers: {
-    logout(state) {
-      state.token = null;
-      state.user = null;
-      localStorage.removeItem("accessToken");
-    },
-  },
+  reducers: {},
   extraReducers: (builder) => {
     builder
       .addCase(loginUser.pending, (state) => {
@@ -109,13 +75,18 @@ const authSlice = createSlice({
       })
       .addCase(loginUser.fulfilled, (state, action) => {
         state.status = "idle";
-        state.token = action.payload.token;
-        state.user = getUserFromToken(action.payload.token);
-        localStorage.setItem("accessToken", action.payload.token);
+        state.token = null;
+        state.user = action.payload.user;
+        state.isAuthenticated = true;
+        state.isInitialized = true;
       })
       .addCase(loginUser.rejected, (state) => {
         state.status = "failed";
         state.error = "Invalid email or password";
+        state.token = null;
+        state.isAuthenticated = false;
+        state.user = null;
+        state.isInitialized = true;
       })
       .addCase(registerUser.pending, (state) => {
         state.status = "loading";
@@ -127,9 +98,36 @@ const authSlice = createSlice({
       .addCase(registerUser.rejected, (state) => {
         state.status = "failed";
         state.error = "Registration failed";
+      })
+      .addCase(fetchSession.pending, (state) => {
+        if (!state.isInitialized) {
+          state.status = "loading";
+        }
+      })
+      .addCase(fetchSession.fulfilled, (state, action) => {
+        state.status = "idle";
+        state.token = null;
+        state.user = action.payload;
+        state.isAuthenticated = true;
+        state.isInitialized = true;
+        state.error = null;
+      })
+      .addCase(fetchSession.rejected, (state) => {
+        state.status = "idle";
+        state.token = null;
+        state.user = null;
+        state.isAuthenticated = false;
+        state.isInitialized = true;
+      })
+      .addCase(logoutUser.fulfilled, (state) => {
+        state.status = "idle";
+        state.token = null;
+        state.user = null;
+        state.isAuthenticated = false;
+        state.isInitialized = true;
+        state.error = null;
       });
   },
 });
 
-export const { logout } = authSlice.actions;
 export const authReducer = authSlice.reducer;

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -35,6 +35,15 @@ const initialState: AuthState = {
   error: null,
 };
 
+const resetLoggedOutState = (state: AuthState) => {
+  state.status = "idle";
+  state.token = null;
+  state.user = null;
+  state.isAuthenticated = false;
+  state.isInitialized = true;
+  state.error = null;
+};
+
 export const loginUser = createAsyncThunk(
   "auth/loginUser",
   async (payload: LoginPayload) => {
@@ -120,12 +129,10 @@ const authSlice = createSlice({
         state.isInitialized = true;
       })
       .addCase(logoutUser.fulfilled, (state) => {
-        state.status = "idle";
-        state.token = null;
-        state.user = null;
-        state.isAuthenticated = false;
-        state.isInitialized = true;
-        state.error = null;
+        resetLoggedOutState(state);
+      })
+      .addCase(logoutUser.rejected, (state) => {
+        resetLoggedOutState(state);
       });
   },
 });

--- a/frontend/src/features/events/api/eventsApi.ts
+++ b/frontend/src/features/events/api/eventsApi.ts
@@ -1,17 +1,10 @@
-import { api, getAuthHeader } from "../../../shared/api/client";
+import { api } from "../../../shared/api/client";
 import type { CreateEventPayload, EventItem } from "../../../types/event";
 
-export const askAssistantQuestionRequest = async (
-  question: string,
-  token: string | null,
-) => {
-  const response = await api.post<{ answer: string }>(
-    "/assistant/questions",
-    { question },
-    {
-      headers: getAuthHeader(token),
-    },
-  );
+export const askAssistantQuestionRequest = async (question: string) => {
+  const response = await api.post<{ answer: string }>("/assistant/questions", {
+    question,
+  });
 
   return response.data;
 };
@@ -23,85 +16,46 @@ export const fetchPublicEventsRequest = async (): Promise<EventItem[]> => {
 
 export const fetchEventByIdRequest = async (
   eventId: string,
-  token: string | null,
 ): Promise<EventItem> => {
-  const response = await api.get<EventItem>(`/events/${eventId}`, {
-    headers: getAuthHeader(token),
-  });
+  const response = await api.get<EventItem>(`/events/${eventId}`);
 
   return response.data;
 };
 
-export const fetchMyEventsRequest = async (
-  token: string | null,
-): Promise<EventItem[]> => {
-  const response = await api.get<EventItem[]>("/users/me/events", {
-    headers: getAuthHeader(token),
-  });
+export const fetchMyEventsRequest = async (): Promise<EventItem[]> => {
+  const response = await api.get<EventItem[]>("/users/me/events");
 
   return response.data;
 };
 
 export const createEventRequest = async (
   payload: CreateEventPayload,
-  token: string | null,
 ): Promise<EventItem> => {
-  const response = await api.post<EventItem>("/events", payload, {
-    headers: getAuthHeader(token),
-  });
+  const response = await api.post<EventItem>("/events", payload);
 
   return response.data;
 };
 
-export const updateEventRequest = async (
-  payload: {
-    eventId: string;
-    data: Partial<CreateEventPayload>;
-  },
-  token: string | null,
-): Promise<EventItem> => {
+export const updateEventRequest = async (payload: {
+  eventId: string;
+  data: Partial<CreateEventPayload>;
+}): Promise<EventItem> => {
   const response = await api.patch<EventItem>(
     `/events/${payload.eventId}`,
     payload.data,
-    {
-      headers: getAuthHeader(token),
-    },
   );
 
   return response.data;
 };
 
-export const deleteEventRequest = async (
-  eventId: string,
-  token: string | null,
-): Promise<void> => {
-  await api.delete(`/events/${eventId}`, {
-    headers: getAuthHeader(token),
-  });
+export const deleteEventRequest = async (eventId: string): Promise<void> => {
+  await api.delete(`/events/${eventId}`);
 };
 
-export const joinEventRequest = async (
-  eventId: string,
-  token: string | null,
-): Promise<void> => {
-  await api.post(
-    `/events/${eventId}/join`,
-    {},
-    {
-      headers: getAuthHeader(token),
-    },
-  );
+export const joinEventRequest = async (eventId: string): Promise<void> => {
+  await api.post(`/events/${eventId}/join`, {});
 };
 
-export const leaveEventRequest = async (
-  eventId: string,
-  token: string | null,
-): Promise<void> => {
-  await api.post(
-    `/events/${eventId}/leave`,
-    {},
-    {
-      headers: getAuthHeader(token),
-    },
-  );
+export const leaveEventRequest = async (eventId: string): Promise<void> => {
+  await api.post(`/events/${eventId}/leave`, {});
 };

--- a/frontend/src/features/events/model/eventsSlice.ts
+++ b/frontend/src/features/events/model/eventsSlice.ts
@@ -1,6 +1,5 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import type { RootState } from "../../../app/store";
-import { logout } from "../../auth/authSlice";
+import { logoutUser } from "../../auth/authSlice";
 import type { CreateEventPayload, EventItem } from "../../../types/event";
 import {
   askAssistantQuestionRequest,
@@ -39,12 +38,8 @@ const initialState: EventsState = {
 
 export const askAssistantQuestion = createAsyncThunk(
   "events/askAssistantQuestion",
-  async (question: string, { getState }) => {
-    const state = getState() as RootState;
-    const response = await askAssistantQuestionRequest(
-      question,
-      state.auth.token,
-    );
+  async (question: string) => {
+    const response = await askAssistantQuestionRequest(question);
 
     return {
       question,
@@ -62,25 +57,22 @@ export const fetchPublicEvents = createAsyncThunk(
 
 export const fetchEventById = createAsyncThunk(
   "events/fetchById",
-  async (eventId: string, { getState }) => {
-    const state = getState() as RootState;
-    return fetchEventByIdRequest(eventId, state.auth.token);
+  async (eventId: string) => {
+    return fetchEventByIdRequest(eventId);
   },
 );
 
 export const fetchMyEvents = createAsyncThunk(
   "events/fetchMyEvents",
-  async (_, { getState }) => {
-    const state = getState() as RootState;
-    return fetchMyEventsRequest(state.auth.token);
+  async () => {
+    return fetchMyEventsRequest();
   },
 );
 
 export const createEvent = createAsyncThunk(
   "events/createEvent",
-  async (payload: CreateEventPayload, { getState }) => {
-    const state = getState() as RootState;
-    return createEventRequest(payload, state.auth.token);
+  async (payload: CreateEventPayload) => {
+    return createEventRequest(payload);
   },
 );
 
@@ -91,18 +83,16 @@ export const updateEvent = createAsyncThunk(
       eventId: string;
       data: Partial<CreateEventPayload>;
     },
-    { getState },
+    _,
   ) => {
-    const state = getState() as RootState;
-    return updateEventRequest(payload, state.auth.token);
+    return updateEventRequest(payload);
   },
 );
 
 export const deleteEvent = createAsyncThunk(
   "events/deleteEvent",
-  async (eventId: string, { getState }) => {
-    const state = getState() as RootState;
-    await deleteEventRequest(eventId, state.auth.token);
+  async (eventId: string) => {
+    await deleteEventRequest(eventId);
 
     return eventId;
   },
@@ -110,9 +100,8 @@ export const deleteEvent = createAsyncThunk(
 
 export const joinEvent = createAsyncThunk(
   "events/joinEvent",
-  async (eventId: string, { getState }) => {
-    const state = getState() as RootState;
-    await joinEventRequest(eventId, state.auth.token);
+  async (eventId: string) => {
+    await joinEventRequest(eventId);
 
     return eventId;
   },
@@ -120,9 +109,8 @@ export const joinEvent = createAsyncThunk(
 
 export const leaveEvent = createAsyncThunk(
   "events/leaveEvent",
-  async (eventId: string, { getState }) => {
-    const state = getState() as RootState;
-    await leaveEventRequest(eventId, state.auth.token);
+  async (eventId: string) => {
+    await leaveEventRequest(eventId);
 
     return eventId;
   },
@@ -134,7 +122,7 @@ const eventsSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
-      .addCase(logout, (state) => {
+      .addCase(logoutUser.fulfilled, (state) => {
         // Clear user-specific data after logout.
         state.myEvents = [];
         state.selectedEvent = null;

--- a/frontend/src/features/events/model/useEventDetailsActions.ts
+++ b/frontend/src/features/events/model/useEventDetailsActions.ts
@@ -22,7 +22,7 @@ import {
 
 type UseEventDetailsActionsParams = {
   currentEvent: EventItem | null;
-  token: string | null;
+  isAuthenticated: boolean;
   returnTo: string;
   navigate: NavigateFunction;
   participantsCount: number;
@@ -32,7 +32,7 @@ type UseEventDetailsActionsParams = {
 
 export const useEventDetailsActions = ({
   currentEvent,
-  token,
+  isAuthenticated,
   returnTo,
   navigate,
   participantsCount,
@@ -51,7 +51,7 @@ export const useEventDetailsActions = ({
 
     await dispatch(fetchEventById(currentEvent.id)).unwrap();
 
-    if (token) {
+    if (isAuthenticated) {
       await dispatch(fetchMyEvents()).unwrap();
     }
   };

--- a/frontend/src/features/events/model/useEventParticipationActions.ts
+++ b/frontend/src/features/events/model/useEventParticipationActions.ts
@@ -9,12 +9,12 @@ import {
 } from "./eventsSlice";
 
 type UseEventParticipationActionsOptions = {
-  token: string | null;
+  isAuthenticated: boolean;
   navigate: NavigateFunction;
 };
 
 export const useEventParticipationActions = ({
-  token,
+  isAuthenticated,
   navigate,
 }: UseEventParticipationActionsOptions) => {
   const dispatch = useAppDispatch();
@@ -57,7 +57,7 @@ export const useEventParticipationActions = ({
   };
 
   const handleLeave = async (eventId: string) => {
-    if (!token) {
+    if (!isAuthenticated) {
       navigate("/login");
       return;
     }

--- a/frontend/src/features/events/ui/event-details/EventCard.tsx
+++ b/frontend/src/features/events/ui/event-details/EventCard.tsx
@@ -9,7 +9,7 @@ import { getTagAccentClassNames } from "../../lib/tagAccent";
 
 type EventCardProps = {
   event: EventItem;
-  token: string | null;
+  isAuthenticated: boolean;
   isOrganizer: boolean;
   isJoined: boolean;
   isBusy: boolean;
@@ -33,7 +33,7 @@ const shortDescription = (description?: string) => {
 
 export function EventCard({
   event,
-  token,
+  isAuthenticated,
   isOrganizer,
   isJoined,
   isBusy,
@@ -145,7 +145,7 @@ export function EventCard({
         className="mt-4"
         onClick={(eventClick) => eventClick.stopPropagation()}
       >
-        {isOrganizer ? null : token && isJoined ? (
+        {isOrganizer ? null : isAuthenticated && isJoined ? (
           <Button
             type="button"
             disabled={isBusy}
@@ -158,7 +158,7 @@ export function EventCard({
           <span className="inline-block w-full rounded-xl bg-slate-200 px-4 py-2 text-center text-[1.05rem] font-semibold text-slate-600">
             Full
           </span>
-        ) : token ? (
+        ) : isAuthenticated ? (
           <Button
             type="button"
             disabled={isBusy}

--- a/frontend/src/features/events/ui/event-details/EventCardGrid.tsx
+++ b/frontend/src/features/events/ui/event-details/EventCardGrid.tsx
@@ -13,17 +13,19 @@ export interface EventCardGridProps {
 export function EventCardGrid({ events }: EventCardGridProps) {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const token = useAppSelector((state) => state.auth.token);
+  const isAuthenticated = useAppSelector(
+    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
+  );
   const currentUserEmail = useAppSelector((state) => state.auth.user?.email);
   const myEvents = useAppSelector((state) => state.events.myEvents);
   const { actionError, busyEventId, handleJoin, handleLeave } =
-    useEventParticipationActions({ token, navigate });
+    useEventParticipationActions({ isAuthenticated, navigate });
 
   useEffect(() => {
-    if (token) {
+    if (isAuthenticated) {
       void dispatch(fetchMyEvents());
     }
-  }, [dispatch, token]);
+  }, [dispatch, isAuthenticated]);
 
   // Fast lookup for join-state rendering on each card.
   const joinedEventIds = useMemo(
@@ -40,7 +42,7 @@ export function EventCardGrid({ events }: EventCardGridProps) {
           <EventCard
             key={event.id}
             event={event}
-            token={token}
+            isAuthenticated={isAuthenticated}
             isOrganizer={
               Boolean(currentUserEmail) &&
               currentUserEmail === event.organizer?.email

--- a/frontend/src/features/events/ui/event-details/EventCardGrid.tsx
+++ b/frontend/src/features/events/ui/event-details/EventCardGrid.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../../../app/hooks";
+import { selectIsAuthenticated } from "../../../auth/authSelectors";
 import { fetchMyEvents } from "../../model/eventsSlice";
 import { useEventParticipationActions } from "../../model/useEventParticipationActions";
 import { EventCard } from "./EventCard";
@@ -13,9 +14,7 @@ export interface EventCardGridProps {
 export function EventCardGrid({ events }: EventCardGridProps) {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const isAuthenticated = useAppSelector(
-    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
-  );
+  const isAuthenticated = useAppSelector(selectIsAuthenticated);
   const currentUserEmail = useAppSelector((state) => state.auth.user?.email);
   const myEvents = useAppSelector((state) => state.events.myEvents);
   const { actionError, busyEventId, handleJoin, handleLeave } =

--- a/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
+++ b/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
@@ -71,7 +71,9 @@ export function EventDetailsInteractionSection({
 }: EventDetailsInteractionSectionProps) {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const token = useAppSelector((state) => state.auth.token);
+  const isAuthenticated = useAppSelector(
+    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
+  );
   const currentUserEmail = useAppSelector((state) => state.auth.user?.email);
   const myEvents = useAppSelector((state) => state.events.myEvents);
   const [isEditing, setIsEditing] = useState(false);
@@ -84,10 +86,10 @@ export function EventDetailsInteractionSection({
   const deleteDialogDescriptionId = useId();
 
   useEffect(() => {
-    if (token) {
+    if (isAuthenticated) {
       void dispatch(fetchMyEvents());
     }
-  }, [dispatch, token]);
+  }, [dispatch, isAuthenticated]);
 
   const joinedEventIds = useMemo(
     () => new Set(myEvents.map((item) => item.id)),
@@ -116,7 +118,7 @@ export function EventDetailsInteractionSection({
     handleEditSubmit,
   } = useEventDetailsActions({
     currentEvent,
-    token,
+    isAuthenticated,
     returnTo,
     navigate,
     participantsCount,
@@ -194,7 +196,7 @@ export function EventDetailsInteractionSection({
   return (
     <>
       <div className="mt-6 flex flex-wrap gap-2">
-        {token ? (
+        {isAuthenticated ? (
           <>
             {/* Participants can join/leave unless they are the organizer. */}
             {!isOrganizer ? (

--- a/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
+++ b/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../../../app/hooks";
+import { selectIsAuthenticated } from "../../../auth/authSelectors";
 import { fetchMyEvents } from "../../model/eventsSlice";
 import { useEventDetailsActions } from "../../model/useEventDetailsActions";
 import type { EventItem } from "../../../../types/event";
@@ -71,9 +72,7 @@ export function EventDetailsInteractionSection({
 }: EventDetailsInteractionSectionProps) {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const isAuthenticated = useAppSelector(
-    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
-  );
+  const isAuthenticated = useAppSelector(selectIsAuthenticated);
   const currentUserEmail = useAppSelector((state) => state.auth.user?.email);
   const myEvents = useAppSelector((state) => state.events.myEvents);
   const [isEditing, setIsEditing] = useState(false);

--- a/frontend/src/pages/CreateEventPage.test.tsx
+++ b/frontend/src/pages/CreateEventPage.test.tsx
@@ -136,11 +136,6 @@ describe("CreateEventPage", () => {
         location: "Kyiv",
         tags: ["AI"],
       }),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: "Bearer test-token",
-        }),
-      }),
     );
   });
 });

--- a/frontend/src/pages/EventDetailsPage.test.tsx
+++ b/frontend/src/pages/EventDetailsPage.test.tsx
@@ -67,7 +67,7 @@ describe("EventDetailsPage", () => {
         error: null,
         assistantAnswer: null,
         assistantStatus: "idle",
-        assistantError: null
+        assistantError: null,
       },
     });
 
@@ -116,7 +116,7 @@ describe("EventDetailsPage", () => {
         error: null,
         assistantAnswer: null,
         assistantStatus: "idle",
-        assistantError: null
+        assistantError: null,
       },
     });
 
@@ -176,7 +176,7 @@ describe("EventDetailsPage", () => {
         error: null,
         assistantAnswer: null,
         assistantStatus: "idle",
-        assistantError: null
+        assistantError: null,
       },
     });
 
@@ -214,7 +214,6 @@ describe("EventDetailsPage", () => {
         visibility: "public",
         tags: ["Business", "Tech"],
       }),
-      expect.any(Object),
     );
   });
 
@@ -260,7 +259,7 @@ describe("EventDetailsPage", () => {
         error: null,
         assistantAnswer: null,
         assistantStatus: "idle",
-        assistantError: null
+        assistantError: null,
       },
     });
 

--- a/frontend/src/pages/EventsPage.test.tsx
+++ b/frontend/src/pages/EventsPage.test.tsx
@@ -306,13 +306,9 @@ describe("EventsPage", () => {
     expect(await screen.findByText("Assistant answer")).toBeInTheDocument();
     expect(screen.getByText("You have 3 events in total.")).toBeInTheDocument();
 
-    expect(postSpy).toHaveBeenCalledWith(
-      "/assistant/questions",
-      { question: "How many events do I have?" },
-      {
-        headers: { Authorization: "Bearer token" },
-      },
-    );
+    expect(postSpy).toHaveBeenCalledWith("/assistant/questions", {
+      question: "How many events do I have?",
+    });
   });
 
   it("keeps assistant live region mounted before answer updates", async () => {

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
+import { selectIsAuthenticated } from "../features/auth/authSelectors";
 import {
   askAssistantQuestion,
   fetchPublicEvents,
@@ -24,9 +25,7 @@ export function EventsPage() {
   const { publicEvents, status, error } = useAppSelector(
     (state) => state.events,
   );
-  const isAuthenticated = useAppSelector(
-    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
-  );
+  const isAuthenticated = useAppSelector(selectIsAuthenticated);
   const {
     searchTerm,
     setSearchTerm,

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -24,7 +24,9 @@ export function EventsPage() {
   const { publicEvents, status, error } = useAppSelector(
     (state) => state.events,
   );
-  const token = useAppSelector((state) => state.auth.token);
+  const isAuthenticated = useAppSelector(
+    (state) => state.auth.isAuthenticated ?? Boolean(state.auth.token),
+  );
   const {
     searchTerm,
     setSearchTerm,
@@ -40,7 +42,7 @@ export function EventsPage() {
   }, [dispatch]);
 
   const handleAssistantSubmit = async (question: string) => {
-    if (!token) {
+    if (!isAuthenticated) {
       return;
     }
 
@@ -59,7 +61,7 @@ export function EventsPage() {
         onSearchTermChange={setSearchTerm}
       />
 
-      {token ? (
+      {isAuthenticated ? (
         <AssistantPanel
           suggestedQuestions={ASSISTANT_QUESTION_SUGGESTIONS}
           onSubmit={handleAssistantSubmit}
@@ -87,4 +89,3 @@ export function EventsPage() {
     </div>
   );
 }
-

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -6,8 +6,86 @@ const apiUrl = rawApiUrl?.trim() || "http://localhost:3001";
 
 export const api = axios.create({
   baseURL: apiUrl,
+  withCredentials: true,
 });
 
-export const getAuthHeader = (token: string | null) =>
-  // Keep call sites simple by returning undefined when no token exists.
-  token ? { Authorization: `Bearer ${token}` } : undefined;
+const CSRF_COOKIE_NAME = "csrf_token";
+const CSRF_HEADER_NAME = "x-csrf-token";
+const SAFE_METHODS = new Set(["get", "head", "options"]);
+
+const getCookieValue = (cookieName: string): string | null => {
+  const escapedCookieName = cookieName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(?:^|; )${escapedCookieName}=([^;]*)`);
+  const match = document.cookie.match(regex);
+
+  if (!match) {
+    return null;
+  }
+
+  return decodeURIComponent(match[1]);
+};
+
+api.interceptors.request.use((config) => {
+  const method = (config.method ?? "get").toLowerCase();
+
+  if (!SAFE_METHODS.has(method)) {
+    const csrfToken = getCookieValue(CSRF_COOKIE_NAME);
+
+    if (csrfToken) {
+      config.headers = config.headers ?? {};
+      config.headers[CSRF_HEADER_NAME] = csrfToken;
+    }
+  }
+
+  return config;
+});
+
+let isRefreshing = false;
+let refreshPromise: Promise<void> | null = null;
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const statusCode = error?.response?.status;
+    const originalRequest = error?.config as
+      | (typeof error.config & { _retry?: boolean; skipAuthRefresh?: boolean })
+      | undefined;
+
+    if (!originalRequest || statusCode !== 401) {
+      throw error;
+    }
+
+    const requestUrl = String(originalRequest.url ?? "");
+    const isAuthEndpoint =
+      requestUrl.includes("/auth/login") ||
+      requestUrl.includes("/auth/register") ||
+      requestUrl.includes("/auth/refresh") ||
+      requestUrl.includes("/auth/logout");
+
+    if (
+      originalRequest._retry ||
+      originalRequest.skipAuthRefresh ||
+      isAuthEndpoint
+    ) {
+      throw error;
+    }
+
+    originalRequest._retry = true;
+
+    if (!isRefreshing) {
+      isRefreshing = true;
+      refreshPromise = api
+        .post("/auth/refresh", {}, {
+          skipAuthRefresh: true,
+        } as any)
+        .then(() => undefined)
+        .finally(() => {
+          isRefreshing = false;
+          refreshPromise = null;
+        });
+    }
+
+    await refreshPromise;
+    return api(originalRequest);
+  },
+);

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,4 +1,7 @@
-import axios from "axios";
+import axios, {
+  type AxiosRequestConfig,
+  type InternalAxiosRequestConfig,
+} from "axios";
 
 const rawApiUrl = import.meta.env.VITE_API_URL;
 // Local backend URL is used when VITE_API_URL is not provided.
@@ -43,12 +46,21 @@ api.interceptors.request.use((config) => {
 let isRefreshing = false;
 let refreshPromise: Promise<void> | null = null;
 
+type RetryAwareRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+  skipAuthRefresh?: boolean;
+};
+
+type RefreshControlConfig = AxiosRequestConfig & {
+  skipAuthRefresh?: boolean;
+};
+
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const statusCode = error?.response?.status;
     const originalRequest = error?.config as
-      | (typeof error.config & { _retry?: boolean; skipAuthRefresh?: boolean })
+      | RetryAwareRequestConfig
       | undefined;
 
     if (!originalRequest || statusCode !== 401) {
@@ -56,6 +68,7 @@ api.interceptors.response.use(
     }
 
     const requestUrl = String(originalRequest.url ?? "");
+    const hasSessionSignal = Boolean(getCookieValue(CSRF_COOKIE_NAME));
     const isAuthEndpoint =
       requestUrl.includes("/auth/login") ||
       requestUrl.includes("/auth/register") ||
@@ -65,6 +78,7 @@ api.interceptors.response.use(
     if (
       originalRequest._retry ||
       originalRequest.skipAuthRefresh ||
+      !hasSessionSignal ||
       isAuthEndpoint
     ) {
       throw error;
@@ -74,10 +88,12 @@ api.interceptors.response.use(
 
     if (!isRefreshing) {
       isRefreshing = true;
+      const refreshConfig: RefreshControlConfig = {
+        skipAuthRefresh: true,
+      };
+
       refreshPromise = api
-        .post("/auth/refresh", {}, {
-          skipAuthRefresh: true,
-        } as any)
+        .post("/auth/refresh", {}, refreshConfig)
         .then(() => undefined)
         .finally(() => {
           isRefreshing = false;


### PR DESCRIPTION
### What changed

- Migrated backend auth core from bearer-token response model to cookie session flow.
- Added secure cookie helpers for access token, refresh token, and csrf token.
- Added csrf protection guard for unsafe HTTP methods when session cookies are present.
- Extended auth with refresh and logout endpoints and cookie lifecycle handling.
- Updated JWT extraction to support cookie-based auth and kept compatibility for bearer extraction paths where needed.
- Refactored frontend auth/session flow to remove localStorage token dependency.
- Added session bootstrap via auth me endpoint on app startup.
- Switched shared frontend API client to credentialed requests, csrf header injection, and refresh retry flow.
- Removed explicit Authorization header passing from events/assistant request paths.
- Updated backend and frontend tests to match the new cookie-session contract.
- Split delivery into 4 logical commits:
- refactor(backend): migrate auth core to cookie sessions
- test(backend): update auth specs for cookie flow
- refactor(frontend): switch auth flow to cookie sessions
- test(frontend): align auth and events tests with cookie api

### Why

- Improve auth security by moving tokens out of browser localStorage.
- Reduce XSS token exfiltration risk with httpOnly cookies.
- Add explicit csrf protection for state-changing requests.
- Keep session continuity with refresh flow and centralized API retry behavior.

### Validation

- Backend unit auth tests: passed (18/18).
- Backend e2e auth tests: passed (6/6).
- Frontend test suite: passed via npm run test:run (41/41).

### Risks/Notes

- Frontend now relies on credentialed cross-origin requests; correct CORS and cookie settings are required in each environment.
- 1CSRF validation is enforced for unsafe methods when session cookies exist.