### PR TITLE
feat(backend): add invitations domain and organizer management api

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { EventsModule } from './events/events.module';
 import { AuthMiddleware } from './auth/auth.middleware';
 import { AssistantModule } from './assistant/assistant.module';
 import { CsrfProtectionGuard } from './auth/csrf-protection.guard';
+import { InvitationsModule } from './invitations/invitations.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { CsrfProtectionGuard } from './auth/csrf-protection.guard';
     UsersModule,
     EventsModule,
     AssistantModule,
+    InvitationsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/database/tables-relations.spec.ts
+++ b/backend/src/database/tables-relations.spec.ts
@@ -5,6 +5,7 @@ import { User } from '../users/entities/user.entity';
 import { Event } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { Tag } from '../tags/entities/tag.entity';
+import { EventInvitation } from '../invitations/entities/event-invitation.entity';
 
 describe('Database tables relations', () => {
   let dataSource: DataSource;
@@ -12,6 +13,7 @@ describe('Database tables relations', () => {
   let eventsRepository: Repository<Event>;
   let participantsRepository: Repository<Participant>;
   let tagsRepository: Repository<Tag>;
+  let invitationsRepository: Repository<EventInvitation>;
 
   beforeAll(async () => {
     const db = newDb({ autoCreateForeignKeyIndices: true });
@@ -37,7 +39,7 @@ describe('Database tables relations', () => {
 
     dataSource = await db.adapters.createTypeormDataSource({
       type: 'postgres',
-      entities: [User, Event, Participant, Tag],
+      entities: [User, Event, Participant, Tag, EventInvitation],
       synchronize: true,
     });
 
@@ -52,6 +54,7 @@ describe('Database tables relations', () => {
     eventsRepository = dataSource.getRepository(Event);
     participantsRepository = dataSource.getRepository(Participant);
     tagsRepository = dataSource.getRepository(Tag);
+    invitationsRepository = dataSource.getRepository(EventInvitation);
   });
 
   afterAll(async () => {
@@ -63,6 +66,7 @@ describe('Database tables relations', () => {
   beforeEach(async () => {
     // Clear join table first to satisfy FK constraints.
     await dataSource.createQueryBuilder().delete().from('event_tags').execute();
+    await invitationsRepository.createQueryBuilder().delete().execute();
     await participantsRepository.createQueryBuilder().delete().execute();
     await tagsRepository.createQueryBuilder().delete().execute();
     await eventsRepository.createQueryBuilder().delete().execute();
@@ -308,5 +312,88 @@ describe('Database tables relations', () => {
 
     expect(eventsCount).toBe(1);
     expect(participantsCount).toBe(0);
+  });
+
+  it('enforces unique invitation pair eventId+invitedUserId', async () => {
+    const organizer = await usersRepository.save(
+      usersRepository.create({
+        email: 'invite-organizer@example.com',
+        password: 'hashed-password',
+        name: 'Invite Organizer',
+      }),
+    );
+
+    const invitedUser = await usersRepository.save(
+      usersRepository.create({
+        email: 'invite-user@example.com',
+        password: 'hashed-password',
+        name: 'Invite User',
+      }),
+    );
+
+    const event = await eventsRepository.save(
+      eventsRepository.create({
+        title: 'Invitation uniqueness event',
+        eventDate: new Date('2026-08-12T12:00:00.000Z'),
+        organizerId: organizer.id,
+      }),
+    );
+
+    await invitationsRepository.save(
+      invitationsRepository.create({
+        eventId: event.id,
+        invitedByUserId: organizer.id,
+        invitedUserId: invitedUser.id,
+      }),
+    );
+
+    await expect(
+      invitationsRepository.save(
+        invitationsRepository.create({
+          eventId: event.id,
+          invitedByUserId: organizer.id,
+          invitedUserId: invitedUser.id,
+        }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('cascades event deletion to invitations', async () => {
+    const organizer = await usersRepository.save(
+      usersRepository.create({
+        email: 'event-delete-organizer@example.com',
+        password: 'hashed-password',
+        name: 'Event Delete Organizer',
+      }),
+    );
+
+    const invitedUser = await usersRepository.save(
+      usersRepository.create({
+        email: 'event-delete-invitee@example.com',
+        password: 'hashed-password',
+        name: 'Event Delete Invitee',
+      }),
+    );
+
+    const event = await eventsRepository.save(
+      eventsRepository.create({
+        title: 'Event invitation cascade test',
+        eventDate: new Date('2026-09-01T12:00:00.000Z'),
+        organizerId: organizer.id,
+      }),
+    );
+
+    await invitationsRepository.save(
+      invitationsRepository.create({
+        eventId: event.id,
+        invitedByUserId: organizer.id,
+        invitedUserId: invitedUser.id,
+      }),
+    );
+
+    await eventsRepository.delete({ id: event.id });
+
+    const invitationsCount = await invitationsRepository.count();
+    expect(invitationsCount).toBe(0);
   });
 });

--- a/backend/src/events/entities/event.entity.ts
+++ b/backend/src/events/entities/event.entity.ts
@@ -12,6 +12,7 @@ import {
 import { User } from '../../users/entities/user.entity';
 import { Participant } from '../../participants/entities/participant.entity';
 import { Tag } from '../../tags/entities/tag.entity';
+import { EventInvitation } from '../../invitations/entities/event-invitation.entity';
 
 export enum EventVisibility {
   PUBLIC = 'public',
@@ -59,6 +60,12 @@ export class Event {
     (participant: Participant): Event => participant.event,
   )
   participants!: Participant[];
+
+  @OneToMany(
+    () => EventInvitation,
+    (invitation: EventInvitation): Event => invitation.event,
+  )
+  invitations!: EventInvitation[];
 
   @ManyToMany(() => Tag, (tag: Tag): Event[] => tag.events)
   @JoinTable({

--- a/backend/src/invitations/dto/create-invitation.dto.ts
+++ b/backend/src/invitations/dto/create-invitation.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class CreateInvitationDto {
+  @ApiProperty({
+    example: '4f3f8c2f-22d5-4f9f-a5ec-9f47d8f83514',
+    description: 'User ID that should receive invitation to the private event',
+  })
+  @IsUUID()
+  invitedUserId!: string;
+}

--- a/backend/src/invitations/entities/event-invitation.entity.ts
+++ b/backend/src/invitations/entities/event-invitation.entity.ts
@@ -1,0 +1,65 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
+import { User } from '../../users/entities/user.entity';
+
+export enum EventInvitationStatus {
+  PENDING = 'pending',
+  ACCEPTED = 'accepted',
+  DECLINED = 'declined',
+  REVOKED = 'revoked',
+}
+
+@Entity('event_invitations')
+@Unique(['eventId', 'invitedUserId'])
+export class EventInvitation {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Event, (event) => event.invitations, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'eventId' })
+  event!: Event;
+
+  @Column({ type: 'uuid' })
+  eventId!: string;
+
+  @ManyToOne(() => User, (user) => user.sentInvitations, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'invitedByUserId' })
+  invitedByUser!: User;
+
+  @Column({ type: 'uuid' })
+  invitedByUserId!: string;
+
+  @ManyToOne(() => User, (user) => user.receivedInvitations, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'invitedUserId' })
+  invitedUser!: User;
+
+  @Column({ type: 'uuid' })
+  invitedUserId!: string;
+
+  @Column({
+    type: 'enum',
+    enum: EventInvitationStatus,
+    default: EventInvitationStatus.PENDING,
+  })
+  status!: EventInvitationStatus;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/invitations/entities/event-invitation.entity.ts
+++ b/backend/src/invitations/entities/event-invitation.entity.ts
@@ -14,7 +14,6 @@ export enum EventInvitationStatus {
   PENDING = 'pending',
   ACCEPTED = 'accepted',
   DECLINED = 'declined',
-  REVOKED = 'revoked',
 }
 
 @Entity('event_invitations')

--- a/backend/src/invitations/invitations.controller.spec.ts
+++ b/backend/src/invitations/invitations.controller.spec.ts
@@ -4,14 +4,25 @@ import { InvitationsService } from './invitations.service';
 
 describe('InvitationsController', () => {
   let controller: InvitationsController;
+  let invitationsService: {
+    createInvitation: jest.Mock;
+    listInvitationsForEvent: jest.Mock;
+    revokeInvitation: jest.Mock;
+  };
 
   beforeEach(async () => {
+    invitationsService = {
+      createInvitation: jest.fn(),
+      listInvitationsForEvent: jest.fn(),
+      revokeInvitation: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [InvitationsController],
       providers: [
         {
           provide: InvitationsService,
-          useValue: {},
+          useValue: invitationsService,
         },
       ],
     }).compile();
@@ -21,5 +32,62 @@ describe('InvitationsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('createInvitation delegates to service with eventId, dto and current user', async () => {
+    const user = { sub: 'organizer-id', email: 'organizer@example.com' };
+    const dto = { invitedUserId: 'invitee-id' };
+    const createdInvitation = {
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedByUserId: user.sub,
+      invitedUserId: dto.invitedUserId,
+    };
+
+    invitationsService.createInvitation.mockResolvedValue(createdInvitation);
+
+    const result = await controller.createInvitation('event-id', dto, user);
+
+    expect(invitationsService.createInvitation).toHaveBeenCalledWith(
+      'event-id',
+      dto,
+      user,
+    );
+    expect(result).toEqual(createdInvitation);
+  });
+
+  it('listInvitations delegates to service with eventId and current user', async () => {
+    const user = { sub: 'organizer-id', email: 'organizer@example.com' };
+    const invitations = [
+      {
+        id: 'invitation-id',
+        eventId: 'event-id',
+        invitedByUserId: user.sub,
+        invitedUserId: 'invitee-id',
+      },
+    ];
+
+    invitationsService.listInvitationsForEvent.mockResolvedValue(invitations);
+
+    const result = await controller.listInvitations('event-id', user);
+
+    expect(invitationsService.listInvitationsForEvent).toHaveBeenCalledWith(
+      'event-id',
+      user,
+    );
+    expect(result).toEqual(invitations);
+  });
+
+  it('revokeInvitation delegates to service with eventId, invitationId and current user', async () => {
+    const user = { sub: 'organizer-id', email: 'organizer@example.com' };
+    invitationsService.revokeInvitation.mockResolvedValue(undefined);
+
+    await controller.revokeInvitation('event-id', 'invitation-id', user);
+
+    expect(invitationsService.revokeInvitation).toHaveBeenCalledWith(
+      'event-id',
+      'invitation-id',
+      user,
+    );
   });
 });

--- a/backend/src/invitations/invitations.controller.spec.ts
+++ b/backend/src/invitations/invitations.controller.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvitationsController } from './invitations.controller';
+import { InvitationsService } from './invitations.service';
+
+describe('InvitationsController', () => {
+  let controller: InvitationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvitationsController],
+      providers: [
+        {
+          provide: InvitationsService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InvitationsController>(InvitationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/invitations/invitations.controller.ts
+++ b/backend/src/invitations/invitations.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { CreateInvitationDto } from './dto/create-invitation.dto';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsService } from './invitations.service';
+
+@ApiTags('event invitations')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('events/:eventId/invitations')
+export class InvitationsController {
+  constructor(private readonly invitationsService: InvitationsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Invite user to private event (organizer only)' })
+  @ApiResponse({ status: 201, description: 'Invitation created successfully' })
+  createInvitation(
+    @Param('eventId') eventId: string,
+    @Body() dto: CreateInvitationDto,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation> {
+    return this.invitationsService.createInvitation(eventId, dto, user);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List private event invitations (organizer only)' })
+  @ApiResponse({ status: 200, description: 'Invitations list' })
+  listInvitations(
+    @Param('eventId') eventId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation[]> {
+    return this.invitationsService.listInvitationsForEvent(eventId, user);
+  }
+
+  @Delete(':invitationId')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Revoke invitation (organizer only)' })
+  @ApiResponse({ status: 204, description: 'Invitation revoked successfully' })
+  async revokeInvitation(
+    @Param('eventId') eventId: string,
+    @Param('invitationId') invitationId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<void> {
+    await this.invitationsService.revokeInvitation(eventId, invitationId, user);
+  }
+}

--- a/backend/src/invitations/invitations.controller.ts
+++ b/backend/src/invitations/invitations.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpCode,
   Param,
+  ParseUUIDPipe,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -31,7 +32,7 @@ export class InvitationsController {
   @ApiOperation({ summary: 'Invite user to private event (organizer only)' })
   @ApiResponse({ status: 201, description: 'Invitation created successfully' })
   createInvitation(
-    @Param('eventId') eventId: string,
+    @Param('eventId', new ParseUUIDPipe()) eventId: string,
     @Body() dto: CreateInvitationDto,
     @CurrentUser() user: { sub: string; email: string },
   ): Promise<EventInvitation> {
@@ -42,7 +43,7 @@ export class InvitationsController {
   @ApiOperation({ summary: 'List private event invitations (organizer only)' })
   @ApiResponse({ status: 200, description: 'Invitations list' })
   listInvitations(
-    @Param('eventId') eventId: string,
+    @Param('eventId', new ParseUUIDPipe()) eventId: string,
     @CurrentUser() user: { sub: string; email: string },
   ): Promise<EventInvitation[]> {
     return this.invitationsService.listInvitationsForEvent(eventId, user);
@@ -53,8 +54,8 @@ export class InvitationsController {
   @ApiOperation({ summary: 'Revoke invitation (organizer only)' })
   @ApiResponse({ status: 204, description: 'Invitation revoked successfully' })
   async revokeInvitation(
-    @Param('eventId') eventId: string,
-    @Param('invitationId') invitationId: string,
+    @Param('eventId', new ParseUUIDPipe()) eventId: string,
+    @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
     @CurrentUser() user: { sub: string; email: string },
   ): Promise<void> {
     await this.invitationsService.revokeInvitation(eventId, invitationId, user);

--- a/backend/src/invitations/invitations.module.ts
+++ b/backend/src/invitations/invitations.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Event } from '../events/entities/event.entity';
+import { Participant } from '../participants/entities/participant.entity';
+import { User } from '../users/entities/user.entity';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsController } from './invitations.controller';
+import { InvitationsService } from './invitations.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([EventInvitation, Event, Participant, User]),
+  ],
+  controllers: [InvitationsController],
+  providers: [InvitationsService],
+  exports: [InvitationsService],
+})
+export class InvitationsModule {}

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -333,6 +333,40 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
+  it('revokes invitation for organizer/private event', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'invitation-id',
+      eventId: 'event-id',
+    });
+
+    invitationsRepository.delete.mockResolvedValue({ affected: 1 });
+
+    await expect(
+      service.revokeInvitation('event-id', 'invitation-id', {
+        sub: 'organizer-id',
+        email: 'organizer@example.com',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(invitationsRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        id: 'invitation-id',
+        eventId: 'event-id',
+      },
+    });
+
+    expect(invitationsRepository.delete).toHaveBeenCalledWith({
+      id: 'invitation-id',
+      eventId: 'event-id',
+    });
+  });
+
   it('throws when invitation to revoke is missing', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -1,10 +1,12 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { QueryFailedError } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
@@ -123,6 +125,22 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
+  it('rejects creating invitation for non-organizer with 403', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'owner-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'another-user-id', email: 'user@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('rejects duplicate invitation pair', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',
@@ -137,6 +155,39 @@ describe('InvitationsService', () => {
       eventId: 'event-id',
       invitedUserId: 'invitee-id',
     });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('maps unique violation on save to conflict for concurrent race', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({ id: 'invitee-id' });
+    participantsRepository.findOne.mockResolvedValue(null);
+    invitationsRepository.findOne.mockResolvedValue(null);
+
+    const invitationPayload = {
+      eventId: 'event-id',
+      invitedByUserId: 'organizer-id',
+      invitedUserId: 'invitee-id',
+    };
+
+    invitationsRepository.create.mockReturnValue(invitationPayload);
+    invitationsRepository.save.mockRejectedValue(
+      new QueryFailedError('insert into event_invitations', [], {
+        code: '23505',
+      }),
+    );
 
     await expect(
       service.createInvitation(

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -1,0 +1,166 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Event, EventVisibility } from '../events/entities/event.entity';
+import { Participant } from '../participants/entities/participant.entity';
+import { User } from '../users/entities/user.entity';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsService } from './invitations.service';
+
+describe('InvitationsService', () => {
+  let service: InvitationsService;
+
+  const invitationsRepository = {
+    create: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const eventsRepository = {
+    findOne: jest.fn(),
+  };
+
+  const participantsRepository = {
+    findOne: jest.fn(),
+  };
+
+  const usersRepository = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvitationsService,
+        {
+          provide: getRepositoryToken(EventInvitation),
+          useValue: invitationsRepository,
+        },
+        {
+          provide: getRepositoryToken(Event),
+          useValue: eventsRepository,
+        },
+        {
+          provide: getRepositoryToken(Participant),
+          useValue: participantsRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<InvitationsService>(InvitationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('creates invitation for private event organizer', async () => {
+    const organizer = { sub: 'organizer-id', email: 'organizer@example.com' };
+
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: organizer.sub,
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({
+      id: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    participantsRepository.findOne.mockResolvedValue(null);
+    invitationsRepository.findOne.mockResolvedValue(null);
+
+    const invitationPayload = {
+      eventId: 'event-id',
+      invitedByUserId: organizer.sub,
+      invitedUserId: 'invitee-id',
+    };
+
+    invitationsRepository.create.mockReturnValue(invitationPayload);
+    invitationsRepository.save.mockResolvedValue({
+      id: 'invitation-id',
+      ...invitationPayload,
+    });
+
+    const result = await service.createInvitation(
+      'event-id',
+      { invitedUserId: 'invitee-id' },
+      organizer,
+    );
+
+    expect(invitationsRepository.create).toHaveBeenCalledWith(
+      invitationPayload,
+    );
+    expect(result.id).toBe('invitation-id');
+  });
+
+  it('rejects creating invitation for public events', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PUBLIC,
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects duplicate invitation pair', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({ id: 'invitee-id' });
+    participantsRepository.findOne.mockResolvedValue(null);
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'existing-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('throws when invitation to revoke is missing', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    invitationsRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.revokeInvitation('event-id', 'missing-invitation-id', {
+        sub: 'organizer-id',
+        email: 'organizer@example.com',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -198,6 +198,76 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(ConflictException);
   });
 
+  it('lists invitations for private event organizer with expected ordering and relations', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    const invitations = [
+      {
+        id: 'invitation-2',
+        eventId: 'event-id',
+        invitedByUserId: 'organizer-id',
+        invitedUserId: 'invitee-2',
+      },
+      {
+        id: 'invitation-1',
+        eventId: 'event-id',
+        invitedByUserId: 'organizer-id',
+        invitedUserId: 'invitee-1',
+      },
+    ];
+
+    invitationsRepository.find.mockResolvedValue(invitations);
+
+    const result = await service.listInvitationsForEvent('event-id', {
+      sub: 'organizer-id',
+      email: 'organizer@example.com',
+    });
+
+    expect(invitationsRepository.find).toHaveBeenCalledWith({
+      where: { eventId: 'event-id' },
+      order: { createdAt: 'DESC' },
+      relations: {
+        invitedByUser: true,
+        invitedUser: true,
+      },
+    });
+    expect(result).toEqual(invitations);
+  });
+
+  it('rejects listing invitations for non-organizer with 403', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'owner-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    await expect(
+      service.listInvitationsForEvent('event-id', {
+        sub: 'another-user-id',
+        email: 'user@example.com',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects listing invitations for public event with 400', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PUBLIC,
+    });
+
+    await expect(
+      service.listInvitationsForEvent('event-id', {
+        sub: 'organizer-id',
+        email: 'organizer@example.com',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
   it('throws when invitation to revoke is missing', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -141,6 +141,71 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
+  it('rejects self-invite with 400', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'organizer-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(usersRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when invited user does not exist', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'missing-user-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('returns 409 when invited user is already a participant', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({
+      id: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    participantsRepository.findOne.mockResolvedValue({
+      id: 'participant-id',
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(invitationsRepository.findOne).not.toHaveBeenCalled();
+  });
+
   it('rejects duplicate invitation pair', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -1,11 +1,12 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
@@ -72,7 +73,15 @@ export class InvitationsService {
       invitedUserId: dto.invitedUserId,
     });
 
-    return this.invitationsRepository.save(invitation);
+    try {
+      return await this.invitationsRepository.save(invitation);
+    } catch (error: unknown) {
+      if (this.isUniqueViolationError(error)) {
+        throw new ConflictException('Invitation already exists for this user');
+      }
+
+      throw error;
+    }
   }
 
   async listInvitationsForEvent(
@@ -128,7 +137,7 @@ export class InvitationsService {
     }
 
     if (event.organizerId !== userId) {
-      throw new BadRequestException('Only organizer can manage invitations');
+      throw new ForbiddenException('Only organizer can manage invitations');
     }
 
     if (event.visibility !== EventVisibility.PRIVATE) {
@@ -136,5 +145,14 @@ export class InvitationsService {
         'Invitations are available only for private events',
       );
     }
+  }
+
+  private isUniqueViolationError(error: unknown): boolean {
+    if (!(error instanceof QueryFailedError)) {
+      return false;
+    }
+
+    const driverError = error.driverError as { code?: string } | undefined;
+    return driverError?.code === '23505';
   }
 }

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -10,7 +10,7 @@ import { QueryFailedError, Repository } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
-import { AuthenticatedUser } from '../events/events.service.helpers';
+import { AuthenticatedUser } from '../common/types/authenticated-request';
 import { CreateInvitationDto } from './dto/create-invitation.dto';
 import { EventInvitation } from './entities/event-invitation.entity';
 

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -1,0 +1,140 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Event, EventVisibility } from '../events/entities/event.entity';
+import { Participant } from '../participants/entities/participant.entity';
+import { User } from '../users/entities/user.entity';
+import { AuthenticatedUser } from '../events/events.service.helpers';
+import { CreateInvitationDto } from './dto/create-invitation.dto';
+import { EventInvitation } from './entities/event-invitation.entity';
+
+@Injectable()
+export class InvitationsService {
+  constructor(
+    @InjectRepository(EventInvitation)
+    private readonly invitationsRepository: Repository<EventInvitation>,
+    @InjectRepository(Event)
+    private readonly eventsRepository: Repository<Event>,
+    @InjectRepository(Participant)
+    private readonly participantsRepository: Repository<Participant>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async createInvitation(
+    eventId: string,
+    dto: CreateInvitationDto,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation> {
+    await this.assertOrganizerCanManageInvitations(eventId, user.sub);
+
+    if (dto.invitedUserId === user.sub) {
+      throw new BadRequestException('Organizer cannot invite themselves');
+    }
+
+    const invitedUser = await this.usersRepository.findOne({
+      where: { id: dto.invitedUserId },
+    });
+
+    if (!invitedUser) {
+      throw new NotFoundException('Invited user not found');
+    }
+
+    const existingParticipant = await this.participantsRepository.findOne({
+      where: { eventId, userId: dto.invitedUserId },
+    });
+
+    if (existingParticipant) {
+      throw new ConflictException(
+        'User is already a participant of this event',
+      );
+    }
+
+    const existingInvitation = await this.invitationsRepository.findOne({
+      where: {
+        eventId,
+        invitedUserId: dto.invitedUserId,
+      },
+    });
+
+    if (existingInvitation) {
+      throw new ConflictException('Invitation already exists for this user');
+    }
+
+    const invitation = this.invitationsRepository.create({
+      eventId,
+      invitedByUserId: user.sub,
+      invitedUserId: dto.invitedUserId,
+    });
+
+    return this.invitationsRepository.save(invitation);
+  }
+
+  async listInvitationsForEvent(
+    eventId: string,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation[]> {
+    await this.assertOrganizerCanManageInvitations(eventId, user.sub);
+
+    return this.invitationsRepository.find({
+      where: { eventId },
+      order: { createdAt: 'DESC' },
+      relations: {
+        invitedByUser: true,
+        invitedUser: true,
+      },
+    });
+  }
+
+  async revokeInvitation(
+    eventId: string,
+    invitationId: string,
+    user: AuthenticatedUser,
+  ): Promise<void> {
+    await this.assertOrganizerCanManageInvitations(eventId, user.sub);
+
+    const invitation = await this.invitationsRepository.findOne({
+      where: {
+        id: invitationId,
+        eventId,
+      },
+    });
+
+    if (!invitation) {
+      throw new NotFoundException('Invitation not found');
+    }
+
+    await this.invitationsRepository.delete({
+      id: invitation.id,
+      eventId,
+    });
+  }
+
+  private async assertOrganizerCanManageInvitations(
+    eventId: string,
+    userId: string,
+  ): Promise<void> {
+    const event = await this.eventsRepository.findOne({
+      where: { id: eventId },
+    });
+
+    if (!event) {
+      throw new NotFoundException('Event not found');
+    }
+
+    if (event.organizerId !== userId) {
+      throw new BadRequestException('Only organizer can manage invitations');
+    }
+
+    if (event.visibility !== EventVisibility.PRIVATE) {
+      throw new BadRequestException(
+        'Invitations are available only for private events',
+      );
+    }
+  }
+}

--- a/backend/src/migrations/1760000007000-CreateEventInvitations.ts
+++ b/backend/src/migrations/1760000007000-CreateEventInvitations.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateEventInvitations1760000007000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "CREATE TYPE \"event_invitations_status_enum\" AS ENUM('pending', 'accepted', 'declined', 'revoked')",
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "event_invitations" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "eventId" uuid NOT NULL,
+        "invitedByUserId" uuid NOT NULL,
+        "invitedUserId" uuid NOT NULL,
+        "status" "event_invitations_status_enum" NOT NULL DEFAULT 'pending',
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_event_invitations_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_event_invitations_event_user" UNIQUE ("eventId", "invitedUserId"),
+        CONSTRAINT "FK_event_invitations_event" FOREIGN KEY ("eventId") REFERENCES "events"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_event_invitations_invited_by_user" FOREIGN KEY ("invitedByUserId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_event_invitations_invited_user" FOREIGN KEY ("invitedUserId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+
+    await queryRunner.query(
+      'CREATE INDEX "IDX_event_invitations_event_id" ON "event_invitations" ("eventId")',
+    );
+
+    await queryRunner.query(
+      'CREATE INDEX "IDX_event_invitations_invited_user_id" ON "event_invitations" ("invitedUserId")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_event_invitations_invited_user_id"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_event_invitations_event_id"',
+    );
+    await queryRunner.query('DROP TABLE "event_invitations"');
+    await queryRunner.query('DROP TYPE "event_invitations_status_enum"');
+  }
+}

--- a/backend/src/migrations/1760000007000-CreateEventInvitations.ts
+++ b/backend/src/migrations/1760000007000-CreateEventInvitations.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class CreateEventInvitations1760000007000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      "CREATE TYPE \"event_invitations_status_enum\" AS ENUM('pending', 'accepted', 'declined', 'revoked')",
+      "CREATE TYPE \"event_invitations_status_enum\" AS ENUM('pending', 'accepted', 'declined')",
     );
 
     await queryRunner.query(`

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm';
 import { Event } from '../../events/entities/event.entity';
 import { Participant } from '../../participants/entities/participant.entity';
+import { EventInvitation } from '../../invitations/entities/event-invitation.entity';
 
 @Entity('users')
 export class User {
@@ -30,4 +31,10 @@ export class User {
 
   @OneToMany(() => Participant, (participant) => participant.user)
   participations!: Participant[];
+
+  @OneToMany(() => EventInvitation, (invitation) => invitation.invitedByUser)
+  sentInvitations!: EventInvitation[];
+
+  @OneToMany(() => EventInvitation, (invitation) => invitation.invitedUser)
+  receivedInvitations!: EventInvitation[];
 }


### PR DESCRIPTION
### What changed

- Added a new invitations domain for private events.
- Implemented EventInvitation entity with status enum and relations to event and users.
- Added organizer-only invitations endpoints:
- POST /events/:eventId/invitations
- GET /events/:eventId/invitations
- DELETE /events/:eventId/invitations/:invitationId
- Added migration to create event_invitations table, enum, constraints, and indexes.
- Wired invitations module into the application module.
- Extended DB relation tests for invitation uniqueness and cascade behavior.
- Added invitations controller and service unit tests.

### Why

- Private events had visibility but no dedicated organizer invitation workflow.
- This PR delivers the backend core needed for invitation management in MVP scope.

### Validation

- Ran backend tests:
- npm test -- invitations
- npm test -- tables-relations
- Result: all tests passed.

### Risks/Notes

- This PR covers organizer management only.
- Accept/decline invitation lifecycle and private access integration are planned for the next backend subtask.