### PR TITLE
feat(backend): add invitation lifecycle and private access integration

### DIFF
--- a/.github/skills/github-delivery-workflow/SKILL.md
+++ b/.github/skills/github-delivery-workflow/SKILL.md
@@ -80,6 +80,23 @@ Field-specific formatting:
   - Risks/Notes
 - Comment: actionable, context-specific, no filler.
 
+## PR Review Reply Rule
+
+After implementing any PR review comment, always provide a short English reply text that is ready to paste into the review thread.
+
+Format guidance:
+
+1. Keep it to 1-3 sentences.
+2. Mention what was changed.
+3. Mention validation briefly when relevant (for example, tests run).
+4. Avoid extra context not needed by reviewer.
+
+Template:
+
+Updated based on your feedback.
+I reused the shared helper to centralize the post-update fetch and remove duplicated not-found handling in both paths.
+Validated with targeted unit/e2e tests.
+
 ## Templates
 
 Title

--- a/backend/src/events/events.service.helpers.ts
+++ b/backend/src/events/events.service.helpers.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException } from '@nestjs/common';
 import { Participant } from '../participants/entities/participant.entity';
 import { Event, EventVisibility } from './entities/event.entity';
+import { EventInvitationStatus } from '../invitations/entities/event-invitation.entity';
 
 export type AuthenticatedUser = {
   sub: string;
@@ -48,8 +49,13 @@ export function assertPrivateEventAccess(
   const isParticipant = event.participants.some(
     (participant) => participant.userId === user.sub,
   );
+  const hasAcceptedInvitation = (event.invitations ?? []).some(
+    (invitation) =>
+      invitation.invitedUserId === user.sub &&
+      invitation.status === EventInvitationStatus.ACCEPTED,
+  );
 
-  if (!isOrganizer && !isParticipant) {
+  if (!isOrganizer && !isParticipant && !hasAcceptedInvitation) {
     throw new ForbiddenException(
       'You do not have access to this private event',
     );

--- a/backend/src/events/events.service.helpers.ts
+++ b/backend/src/events/events.service.helpers.ts
@@ -62,7 +62,7 @@ export function assertPrivateEventAccess(
   }
 }
 
-export function sanitizeParticipantEmails(event: Event): Event {
+export function sanitizeEventForAuthenticatedView(event: Event): Event {
   // Remove participant email from API responses while preserving other user fields.
   const sanitizedParticipants = (event.participants ?? []).map(
     (participant) => {

--- a/backend/src/events/events.service.helpers.ts
+++ b/backend/src/events/events.service.helpers.ts
@@ -79,8 +79,10 @@ export function sanitizeParticipantEmails(event: Event): Event {
     },
   );
 
+  const { invitations: _invitations, ...eventWithoutInvitations } = event;
+
   return {
-    ...event,
+    ...eventWithoutInvitations,
     participants: sanitizedParticipants as Participant[],
-  };
+  } as Event;
 }

--- a/backend/src/events/events.service.spec.ts
+++ b/backend/src/events/events.service.spec.ts
@@ -646,6 +646,7 @@ describe('EventsService', () => {
     );
 
     expect(result.participants?.[0]?.user).not.toHaveProperty('email');
+    expect(result).not.toHaveProperty('invitations');
   });
 
   it('findOne throws when unauthenticated user requests private event', async () => {

--- a/backend/src/events/events.service.spec.ts
+++ b/backend/src/events/events.service.spec.ts
@@ -630,7 +630,12 @@ describe('EventsService', () => {
     expect(eventsRepository.findOne).toHaveBeenCalledTimes(1);
     expect(eventsRepository.findOne).toHaveBeenCalledWith({
       where: { id: 'event-id' },
-      relations: { organizer: true, participants: { user: true }, tags: true },
+      relations: {
+        organizer: true,
+        participants: { user: true },
+        invitations: true,
+        tags: true,
+      },
     });
 
     expect(result.participants?.[0]?.user).toEqual(
@@ -707,7 +712,12 @@ describe('EventsService', () => {
     expect(eventsRepository.findOne).toHaveBeenCalledTimes(1);
     expect(eventsRepository.findOne).toHaveBeenCalledWith({
       where: { id: 'event-id' },
-      relations: { organizer: true, participants: { user: true }, tags: true },
+      relations: {
+        organizer: true,
+        participants: { user: true },
+        invitations: true,
+        tags: true,
+      },
     });
 
     expect(result.participants?.[0]?.user).not.toHaveProperty('email');
@@ -719,6 +729,7 @@ describe('EventsService', () => {
       visibility: 'private',
       organizerId: 'organizer-id',
       participants: [{ userId: 'participant-id' }],
+      invitations: [],
     });
 
     await expect(
@@ -727,6 +738,32 @@ describe('EventsService', () => {
         email: 'another@example.com',
       }),
     ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('findOne returns private event to user with accepted invitation', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      visibility: 'private',
+      organizerId: 'organizer-id',
+      participants: [],
+      invitations: [
+        {
+          invitedUserId: 'invited-user-id',
+          status: 'accepted',
+        },
+      ],
+    });
+
+    const result = await service.findOne('event-id', {
+      sub: 'invited-user-id',
+      email: 'invited@example.com',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'event-id',
+      }),
+    );
   });
 
   it('joinEvent throws when capacity is reached', async () => {

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -75,7 +75,12 @@ export class EventsService {
 
   async findOne(id: string, user?: AuthenticatedUser): Promise<Event> {
     const relations = user
-      ? { organizer: true, participants: { user: true }, tags: true }
+      ? {
+          organizer: true,
+          participants: { user: true },
+          invitations: true,
+          tags: true,
+        }
       : { organizer: true, participants: true, tags: true };
 
     const event = await this.eventsRepository.findOne({

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -14,7 +14,7 @@ import {
   assertPrivateEventAccess,
   AuthenticatedUser,
   mergeAndSortCalendarEvents,
-  sanitizeParticipantEmails,
+  sanitizeEventForAuthenticatedView,
 } from './events.service.helpers';
 import {
   assertCapacityAvailable,
@@ -94,7 +94,7 @@ export class EventsService {
 
     assertPrivateEventAccess(event, user);
 
-    return user ? sanitizeParticipantEmails(event) : event;
+    return user ? sanitizeEventForAuthenticatedView(event) : event;
   }
 
   async create(

--- a/backend/src/invitations/invitations-lifecycle.controller.spec.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvitationsLifecycleController } from './invitations-lifecycle.controller';
+import { InvitationsService } from './invitations.service';
+
+describe('InvitationsLifecycleController', () => {
+  let controller: InvitationsLifecycleController;
+  let invitationsService: {
+    listMyInvitations: jest.Mock;
+    acceptInvitation: jest.Mock;
+    declineInvitation: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    invitationsService = {
+      listMyInvitations: jest.fn(),
+      acceptInvitation: jest.fn(),
+      declineInvitation: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvitationsLifecycleController],
+      providers: [
+        {
+          provide: InvitationsService,
+          useValue: invitationsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InvitationsLifecycleController>(
+      InvitationsLifecycleController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('listMyInvitations delegates to service with current user', async () => {
+    const user = { sub: 'invitee-id', email: 'invitee@example.com' };
+    const invitations = [{ id: 'invitation-id' }];
+
+    invitationsService.listMyInvitations.mockResolvedValue(invitations);
+
+    const result = await controller.listMyInvitations(user);
+
+    expect(invitationsService.listMyInvitations).toHaveBeenCalledWith(user);
+    expect(result).toEqual(invitations);
+  });
+
+  it('acceptInvitation delegates to service with invitation id and current user', async () => {
+    const user = { sub: 'invitee-id', email: 'invitee@example.com' };
+
+    invitationsService.acceptInvitation.mockResolvedValue({
+      id: 'invitation-id',
+      status: 'accepted',
+    });
+
+    const result = await controller.acceptInvitation('invitation-id', user);
+
+    expect(invitationsService.acceptInvitation).toHaveBeenCalledWith(
+      'invitation-id',
+      user,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'invitation-id',
+        status: 'accepted',
+      }),
+    );
+  });
+
+  it('declineInvitation delegates to service with invitation id and current user', async () => {
+    const user = { sub: 'invitee-id', email: 'invitee@example.com' };
+
+    invitationsService.declineInvitation.mockResolvedValue({
+      id: 'invitation-id',
+      status: 'declined',
+    });
+
+    const result = await controller.declineInvitation('invitation-id', user);
+
+    expect(invitationsService.declineInvitation).toHaveBeenCalledWith(
+      'invitation-id',
+      user,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'invitation-id',
+        status: 'declined',
+      }),
+    );
+  });
+});

--- a/backend/src/invitations/invitations-lifecycle.controller.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.ts
@@ -46,8 +46,9 @@ export class InvitationsLifecycleController {
   }
 
   @Post(':invitationId/decline')
+  @HttpCode(200)
   @ApiOperation({ summary: 'Decline invitation for current user' })
-  @ApiResponse({ status: 201, description: 'Invitation declined' })
+  @ApiResponse({ status: 200, description: 'Invitation declined' })
   declineInvitation(
     @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
     @CurrentUser() user: { sub: string; email: string },

--- a/backend/src/invitations/invitations-lifecycle.controller.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  HttpCode,
   Param,
   ParseUUIDPipe,
   Post,
@@ -34,8 +35,9 @@ export class InvitationsLifecycleController {
   }
 
   @Post(':invitationId/accept')
+  @HttpCode(200)
   @ApiOperation({ summary: 'Accept invitation for current user' })
-  @ApiResponse({ status: 201, description: 'Invitation accepted' })
+  @ApiResponse({ status: 200, description: 'Invitation accepted' })
   acceptInvitation(
     @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
     @CurrentUser() user: { sub: string; email: string },

--- a/backend/src/invitations/invitations-lifecycle.controller.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsService } from './invitations.service';
+
+@ApiTags('invitations')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('invitations')
+export class InvitationsLifecycleController {
+  constructor(private readonly invitationsService: InvitationsService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'List invitations for current user' })
+  @ApiResponse({ status: 200, description: 'Current user invitations list' })
+  listMyInvitations(
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation[]> {
+    return this.invitationsService.listMyInvitations(user);
+  }
+
+  @Post(':invitationId/accept')
+  @ApiOperation({ summary: 'Accept invitation for current user' })
+  @ApiResponse({ status: 201, description: 'Invitation accepted' })
+  acceptInvitation(
+    @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation> {
+    return this.invitationsService.acceptInvitation(invitationId, user);
+  }
+
+  @Post(':invitationId/decline')
+  @ApiOperation({ summary: 'Decline invitation for current user' })
+  @ApiResponse({ status: 201, description: 'Invitation declined' })
+  declineInvitation(
+    @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation> {
+    return this.invitationsService.declineInvitation(invitationId, user);
+  }
+}

--- a/backend/src/invitations/invitations.module.ts
+++ b/backend/src/invitations/invitations.module.ts
@@ -4,6 +4,7 @@ import { Event } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
 import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsLifecycleController } from './invitations-lifecycle.controller';
 import { InvitationsController } from './invitations.controller';
 import { InvitationsService } from './invitations.service';
 
@@ -11,7 +12,7 @@ import { InvitationsService } from './invitations.service';
   imports: [
     TypeOrmModule.forFeature([EventInvitation, Event, Participant, User]),
   ],
-  controllers: [InvitationsController],
+  controllers: [InvitationsController, InvitationsLifecycleController],
   providers: [InvitationsService],
   exports: [InvitationsService],
 })

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -441,6 +441,64 @@ describe('InvitationsService', () => {
     expect(result).toEqual(invitations);
   });
 
+  it('listMyInvitations hides private event details for non-accepted invitations', async () => {
+    const invitations = [
+      {
+        id: 'pending-invitation-id',
+        invitedUserId: 'invitee-id',
+        status: EventInvitationStatus.PENDING,
+        event: {
+          id: 'private-event-id',
+          title: 'Private party',
+          description: 'Sensitive details',
+          location: 'Secret location',
+          capacity: 10,
+          visibility: EventVisibility.PRIVATE,
+        },
+      },
+      {
+        id: 'accepted-invitation-id',
+        invitedUserId: 'invitee-id',
+        status: EventInvitationStatus.ACCEPTED,
+        event: {
+          id: 'private-event-id-2',
+          title: 'Private party accepted',
+          description: 'Visible details',
+          location: 'Visible location',
+          capacity: 20,
+          visibility: EventVisibility.PRIVATE,
+        },
+      },
+    ];
+
+    invitationsRepository.find.mockResolvedValue(invitations);
+
+    const result = await service.listMyInvitations({
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(result[0].event).toEqual(
+      expect.objectContaining({
+        id: 'private-event-id',
+        title: 'Private party',
+        visibility: EventVisibility.PRIVATE,
+      }),
+    );
+    expect(result[0].event?.description).toBeUndefined();
+    expect(result[0].event?.location).toBeUndefined();
+    expect(result[0].event?.capacity).toBeUndefined();
+
+    expect(result[1].event).toEqual(
+      expect.objectContaining({
+        id: 'private-event-id-2',
+        description: 'Visible details',
+        location: 'Visible location',
+        capacity: 20,
+      }),
+    );
+  });
+
   it('acceptInvitation updates status and creates participant for pending invitation', async () => {
     const invitation = {
       id: 'invitation-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -26,6 +26,7 @@ describe('InvitationsService', () => {
     create: jest.fn(),
     find: jest.fn(),
     findOne: jest.fn(),
+    update: jest.fn(),
     save: jest.fn(),
     delete: jest.fn(),
     manager: {
@@ -449,6 +450,13 @@ describe('InvitationsService', () => {
     };
 
     invitationsRepository.findOne.mockResolvedValue(invitation);
+    invitationsRepository.update.mockResolvedValue({ affected: 1 });
+    invitationsRepository.findOne
+      .mockResolvedValueOnce(invitation)
+      .mockResolvedValueOnce({
+        ...invitation,
+        status: EventInvitationStatus.ACCEPTED,
+      });
     invitationsRepository.save.mockResolvedValue({
       ...invitation,
       status: EventInvitationStatus.ACCEPTED,
@@ -494,6 +502,8 @@ describe('InvitationsService', () => {
       status: EventInvitationStatus.DECLINED,
     });
 
+    invitationsRepository.update.mockResolvedValue({ affected: 0 });
+
     await expect(
       service.acceptInvitation('invitation-id', {
         sub: 'invitee-id',
@@ -512,11 +522,13 @@ describe('InvitationsService', () => {
       status: EventInvitationStatus.PENDING,
     };
 
-    invitationsRepository.findOne.mockResolvedValue(invitation);
-    invitationsRepository.save.mockResolvedValue({
-      ...invitation,
-      status: EventInvitationStatus.DECLINED,
-    });
+    invitationsRepository.update.mockResolvedValue({ affected: 1 });
+    invitationsRepository.findOne
+      .mockResolvedValueOnce(invitation)
+      .mockResolvedValueOnce({
+        ...invitation,
+        status: EventInvitationStatus.DECLINED,
+      });
 
     const result = await service.declineInvitation('invitation-id', {
       sub: 'invitee-id',
@@ -528,5 +540,22 @@ describe('InvitationsService', () => {
         status: EventInvitationStatus.DECLINED,
       }),
     );
+  });
+
+  it('declineInvitation rejects non-pending invitation', async () => {
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.ACCEPTED,
+    });
+    invitationsRepository.update.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      service.declineInvitation('invitation-id', {
+        sub: 'invitee-id',
+        email: 'invitee@example.com',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -474,9 +474,6 @@ describe('InvitationsService', () => {
         id: 'invitation-id',
         invitedUserId: 'invitee-id',
       },
-      relations: {
-        event: true,
-      },
     });
     expect(participantsRepository.create).toHaveBeenCalledWith({
       eventId: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -18,6 +18,9 @@ import { InvitationsService } from './invitations.service';
 
 describe('InvitationsService', () => {
   let service: InvitationsService;
+  let transactionManager: {
+    getRepository: jest.Mock;
+  };
 
   const invitationsRepository = {
     create: jest.fn(),
@@ -25,6 +28,9 @@ describe('InvitationsService', () => {
     findOne: jest.fn(),
     save: jest.fn(),
     delete: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
 
   const eventsRepository = {
@@ -43,6 +49,28 @@ describe('InvitationsService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+
+    transactionManager = {
+      getRepository: jest.fn((entity: unknown) => {
+        if (entity === EventInvitation) {
+          return invitationsRepository;
+        }
+
+        if (entity === Participant) {
+          return participantsRepository;
+        }
+
+        return undefined;
+      }),
+    };
+
+    invitationsRepository.manager.transaction.mockImplementation(
+      (
+        callback: (
+          manager: typeof transactionManager,
+        ) => Promise<unknown> | unknown,
+      ) => Promise.resolve(callback(transactionManager)),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -10,7 +10,10 @@ import { QueryFailedError } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
-import { EventInvitation } from './entities/event-invitation.entity';
+import {
+  EventInvitation,
+  EventInvitationStatus,
+} from './entities/event-invitation.entity';
 import { InvitationsService } from './invitations.service';
 
 describe('InvitationsService', () => {
@@ -30,6 +33,8 @@ describe('InvitationsService', () => {
 
   const participantsRepository = {
     findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
   };
 
   const usersRepository = {
@@ -247,11 +252,14 @@ describe('InvitationsService', () => {
       invitedUserId: 'invitee-id',
     };
 
+    const driverError = new Error('duplicate invitation') as Error & {
+      code: string;
+    };
+    driverError.code = '23505';
+
     invitationsRepository.create.mockReturnValue(invitationPayload);
     invitationsRepository.save.mockRejectedValue(
-      new QueryFailedError('insert into event_invitations', [], {
-        code: '23505',
-      }),
+      new QueryFailedError('insert into event_invitations', [], driverError),
     );
 
     await expect(
@@ -382,5 +390,118 @@ describe('InvitationsService', () => {
         email: 'organizer@example.com',
       }),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('listMyInvitations returns current user invitations with relations and ordering', async () => {
+    const invitations = [{ id: 'invitation-id', invitedUserId: 'invitee-id' }];
+    invitationsRepository.find.mockResolvedValue(invitations);
+
+    const result = await service.listMyInvitations({
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(invitationsRepository.find).toHaveBeenCalledWith({
+      where: { invitedUserId: 'invitee-id' },
+      order: { createdAt: 'DESC' },
+      relations: {
+        event: { organizer: true, tags: true },
+        invitedByUser: true,
+      },
+    });
+    expect(result).toEqual(invitations);
+  });
+
+  it('acceptInvitation updates status and creates participant for pending invitation', async () => {
+    const invitation = {
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.PENDING,
+    };
+
+    invitationsRepository.findOne.mockResolvedValue(invitation);
+    invitationsRepository.save.mockResolvedValue({
+      ...invitation,
+      status: EventInvitationStatus.ACCEPTED,
+    });
+    participantsRepository.findOne.mockResolvedValue(null);
+    participantsRepository.create.mockReturnValue({
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+    participantsRepository.save.mockResolvedValue({
+      id: 'participant-id',
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+
+    const result = await service.acceptInvitation('invitation-id', {
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(invitationsRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        id: 'invitation-id',
+        invitedUserId: 'invitee-id',
+      },
+      relations: {
+        event: true,
+      },
+    });
+    expect(participantsRepository.create).toHaveBeenCalledWith({
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: EventInvitationStatus.ACCEPTED,
+      }),
+    );
+  });
+
+  it('acceptInvitation rejects non-pending invitation', async () => {
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.DECLINED,
+    });
+
+    await expect(
+      service.acceptInvitation('invitation-id', {
+        sub: 'invitee-id',
+        email: 'invitee@example.com',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(participantsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('declineInvitation updates status for pending invitation', async () => {
+    const invitation = {
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.PENDING,
+    };
+
+    invitationsRepository.findOne.mockResolvedValue(invitation);
+    invitationsRepository.save.mockResolvedValue({
+      ...invitation,
+      status: EventInvitationStatus.DECLINED,
+    });
+
+    const result = await service.declineInvitation('invitation-id', {
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: EventInvitationStatus.DECLINED,
+      }),
+    );
   });
 });

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -12,7 +12,10 @@ import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
 import { AuthenticatedUser } from '../common/types/authenticated-request';
 import { CreateInvitationDto } from './dto/create-invitation.dto';
-import { EventInvitation } from './entities/event-invitation.entity';
+import {
+  EventInvitation,
+  EventInvitationStatus,
+} from './entities/event-invitation.entity';
 
 @Injectable()
 export class InvitationsService {
@@ -124,6 +127,75 @@ export class InvitationsService {
     });
   }
 
+  async listMyInvitations(user: AuthenticatedUser): Promise<EventInvitation[]> {
+    return this.invitationsRepository.find({
+      where: { invitedUserId: user.sub },
+      order: { createdAt: 'DESC' },
+      relations: {
+        event: { organizer: true, tags: true },
+        invitedByUser: true,
+      },
+    });
+  }
+
+  async acceptInvitation(
+    invitationId: string,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation> {
+    const invitation = await this.getInvitationForInvitedUser(
+      invitationId,
+      user.sub,
+    );
+
+    if (invitation.status !== EventInvitationStatus.PENDING) {
+      throw new ConflictException('Invitation is not pending');
+    }
+
+    invitation.status = EventInvitationStatus.ACCEPTED;
+    const savedInvitation = await this.invitationsRepository.save(invitation);
+
+    const existingParticipant = await this.participantsRepository.findOne({
+      where: {
+        eventId: invitation.eventId,
+        userId: user.sub,
+      },
+    });
+
+    if (!existingParticipant) {
+      const participant = this.participantsRepository.create({
+        eventId: invitation.eventId,
+        userId: user.sub,
+      });
+
+      try {
+        await this.participantsRepository.save(participant);
+      } catch (error: unknown) {
+        if (!this.isUniqueViolationError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    return savedInvitation;
+  }
+
+  async declineInvitation(
+    invitationId: string,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation> {
+    const invitation = await this.getInvitationForInvitedUser(
+      invitationId,
+      user.sub,
+    );
+
+    if (invitation.status !== EventInvitationStatus.PENDING) {
+      throw new ConflictException('Invitation is not pending');
+    }
+
+    invitation.status = EventInvitationStatus.DECLINED;
+    return this.invitationsRepository.save(invitation);
+  }
+
   private async assertOrganizerCanManageInvitations(
     eventId: string,
     userId: string,
@@ -154,5 +226,26 @@ export class InvitationsService {
 
     const driverError = error.driverError as { code?: string } | undefined;
     return driverError?.code === '23505';
+  }
+
+  private async getInvitationForInvitedUser(
+    invitationId: string,
+    invitedUserId: string,
+  ): Promise<EventInvitation> {
+    const invitation = await this.invitationsRepository.findOne({
+      where: {
+        id: invitationId,
+        invitedUserId,
+      },
+      relations: {
+        event: true,
+      },
+    });
+
+    if (!invitation) {
+      throw new NotFoundException('Invitation not found');
+    }
+
+    return invitation;
   }
 }

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -128,7 +128,7 @@ export class InvitationsService {
   }
 
   async listMyInvitations(user: AuthenticatedUser): Promise<EventInvitation[]> {
-    return this.invitationsRepository.find({
+    const invitations = await this.invitationsRepository.find({
       where: { invitedUserId: user.sub },
       order: { createdAt: 'DESC' },
       relations: {
@@ -136,6 +136,10 @@ export class InvitationsService {
         invitedByUser: true,
       },
     });
+
+    return invitations.map((invitation) =>
+      this.sanitizeInvitationForInviteeView(invitation),
+    );
   }
 
   async acceptInvitation(
@@ -287,5 +291,35 @@ export class InvitationsService {
     }
 
     return invitation;
+  }
+
+  private sanitizeInvitationForInviteeView(
+    invitation: EventInvitation,
+  ): EventInvitation {
+    const event = invitation.event;
+
+    if (!event) {
+      return invitation;
+    }
+
+    const shouldHidePrivateDetails =
+      event.visibility === EventVisibility.PRIVATE &&
+      invitation.status !== EventInvitationStatus.ACCEPTED;
+
+    if (!shouldHidePrivateDetails) {
+      return invitation;
+    }
+
+    const {
+      description: _description,
+      location: _location,
+      capacity: _capacity,
+      ...eventPreview
+    } = event;
+
+    return {
+      ...invitation,
+      event: eventPreview as Event,
+    };
   }
 }

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -192,19 +192,11 @@ export class InvitationsService {
         }
       }
 
-      const updatedInvitation =
-        await transactionalInvitationsRepository.findOne({
-          where: {
-            id: invitation.id,
-            invitedUserId: user.sub,
-          },
-        });
-
-      if (!updatedInvitation) {
-        throw new NotFoundException('Invitation not found');
-      }
-
-      return updatedInvitation;
+      return this.getInvitationForInvitedUser(
+        invitation.id,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
     });
   }
 
@@ -237,19 +229,11 @@ export class InvitationsService {
         throw new ConflictException('Invitation is not pending');
       }
 
-      const updatedInvitation =
-        await transactionalInvitationsRepository.findOne({
-          where: {
-            id: invitation.id,
-            invitedUserId: user.sub,
-          },
-        });
-
-      if (!updatedInvitation) {
-        throw new NotFoundException('Invitation not found');
-      }
-
-      return updatedInvitation;
+      return this.getInvitationForInvitedUser(
+        invitation.id,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
     });
   }
 

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -142,41 +142,51 @@ export class InvitationsService {
     invitationId: string,
     user: AuthenticatedUser,
   ): Promise<EventInvitation> {
-    const invitation = await this.getInvitationForInvitedUser(
-      invitationId,
-      user.sub,
-    );
+    return this.invitationsRepository.manager.transaction(async (manager) => {
+      const transactionalInvitationsRepository =
+        manager.getRepository(EventInvitation);
+      const transactionalParticipantsRepository =
+        manager.getRepository(Participant);
 
-    if (invitation.status !== EventInvitationStatus.PENDING) {
-      throw new ConflictException('Invitation is not pending');
-    }
+      const invitation = await this.getInvitationForInvitedUser(
+        invitationId,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
 
-    invitation.status = EventInvitationStatus.ACCEPTED;
-    const savedInvitation = await this.invitationsRepository.save(invitation);
+      if (invitation.status !== EventInvitationStatus.PENDING) {
+        throw new ConflictException('Invitation is not pending');
+      }
 
-    const existingParticipant = await this.participantsRepository.findOne({
-      where: {
-        eventId: invitation.eventId,
-        userId: user.sub,
-      },
-    });
+      invitation.status = EventInvitationStatus.ACCEPTED;
+      const savedInvitation =
+        await transactionalInvitationsRepository.save(invitation);
 
-    if (!existingParticipant) {
-      const participant = this.participantsRepository.create({
-        eventId: invitation.eventId,
-        userId: user.sub,
-      });
+      const existingParticipant =
+        await transactionalParticipantsRepository.findOne({
+          where: {
+            eventId: invitation.eventId,
+            userId: user.sub,
+          },
+        });
 
-      try {
-        await this.participantsRepository.save(participant);
-      } catch (error: unknown) {
-        if (!this.isUniqueViolationError(error)) {
-          throw error;
+      if (!existingParticipant) {
+        const participant = transactionalParticipantsRepository.create({
+          eventId: invitation.eventId,
+          userId: user.sub,
+        });
+
+        try {
+          await transactionalParticipantsRepository.save(participant);
+        } catch (error: unknown) {
+          if (!this.isUniqueViolationError(error)) {
+            throw error;
+          }
         }
       }
-    }
 
-    return savedInvitation;
+      return savedInvitation;
+    });
   }
 
   async declineInvitation(
@@ -231,8 +241,10 @@ export class InvitationsService {
   private async getInvitationForInvitedUser(
     invitationId: string,
     invitedUserId: string,
+    invitationsRepository: Repository<EventInvitation> = this
+      .invitationsRepository,
   ): Promise<EventInvitation> {
-    const invitation = await this.invitationsRepository.findOne({
+    const invitation = await invitationsRepository.findOne({
       where: {
         id: invitationId,
         invitedUserId,

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -154,13 +154,20 @@ export class InvitationsService {
         transactionalInvitationsRepository,
       );
 
-      if (invitation.status !== EventInvitationStatus.PENDING) {
+      const updateResult = await transactionalInvitationsRepository.update(
+        {
+          id: invitation.id,
+          invitedUserId: user.sub,
+          status: EventInvitationStatus.PENDING,
+        },
+        {
+          status: EventInvitationStatus.ACCEPTED,
+        },
+      );
+
+      if (updateResult.affected !== 1) {
         throw new ConflictException('Invitation is not pending');
       }
-
-      invitation.status = EventInvitationStatus.ACCEPTED;
-      const savedInvitation =
-        await transactionalInvitationsRepository.save(invitation);
 
       const existingParticipant =
         await transactionalParticipantsRepository.findOne({
@@ -185,7 +192,19 @@ export class InvitationsService {
         }
       }
 
-      return savedInvitation;
+      const updatedInvitation =
+        await transactionalInvitationsRepository.findOne({
+          where: {
+            id: invitation.id,
+            invitedUserId: user.sub,
+          },
+        });
+
+      if (!updatedInvitation) {
+        throw new NotFoundException('Invitation not found');
+      }
+
+      return updatedInvitation;
     });
   }
 
@@ -193,17 +212,45 @@ export class InvitationsService {
     invitationId: string,
     user: AuthenticatedUser,
   ): Promise<EventInvitation> {
-    const invitation = await this.getInvitationForInvitedUser(
-      invitationId,
-      user.sub,
-    );
+    return this.invitationsRepository.manager.transaction(async (manager) => {
+      const transactionalInvitationsRepository =
+        manager.getRepository(EventInvitation);
 
-    if (invitation.status !== EventInvitationStatus.PENDING) {
-      throw new ConflictException('Invitation is not pending');
-    }
+      const invitation = await this.getInvitationForInvitedUser(
+        invitationId,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
 
-    invitation.status = EventInvitationStatus.DECLINED;
-    return this.invitationsRepository.save(invitation);
+      const updateResult = await transactionalInvitationsRepository.update(
+        {
+          id: invitation.id,
+          invitedUserId: user.sub,
+          status: EventInvitationStatus.PENDING,
+        },
+        {
+          status: EventInvitationStatus.DECLINED,
+        },
+      );
+
+      if (updateResult.affected !== 1) {
+        throw new ConflictException('Invitation is not pending');
+      }
+
+      const updatedInvitation =
+        await transactionalInvitationsRepository.findOne({
+          where: {
+            id: invitation.id,
+            invitedUserId: user.sub,
+          },
+        });
+
+      if (!updatedInvitation) {
+        throw new NotFoundException('Invitation not found');
+      }
+
+      return updatedInvitation;
+    });
   }
 
   private async assertOrganizerCanManageInvitations(

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -249,9 +249,6 @@ export class InvitationsService {
         id: invitationId,
         invitedUserId,
       },
-      relations: {
-        event: true,
-      },
     });
 
     if (!invitation) {

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -455,7 +455,7 @@ describe('Invitations lifecycle (e2e)', () => {
     await request(httpServer)
       .post(`/invitations/${invitationToDeclineId}/decline`)
       .set('Authorization', 'Bearer invitee-token')
-      .expect(201)
+      .expect(200)
       .expect((response) => {
         expect(response.body).toEqual(
           expect.objectContaining({

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -31,6 +31,43 @@ type InvitationRecord = {
   createdAt: Date;
 };
 
+type TestAuthUser = {
+  sub: string;
+  email: string;
+};
+
+function resolveUserFromToken(
+  token: string | undefined,
+  users: {
+    organizer: { id: string; email: string };
+    invitee: { id: string; email: string };
+    stranger: { id: string; email: string };
+  },
+): TestAuthUser | undefined {
+  if (token === 'organizer-token') {
+    return {
+      sub: users.organizer.id,
+      email: users.organizer.email,
+    };
+  }
+
+  if (token === 'invitee-token') {
+    return {
+      sub: users.invitee.id,
+      email: users.invitee.email,
+    };
+  }
+
+  if (token === 'stranger-token') {
+    return {
+      sub: users.stranger.id,
+      email: users.stranger.email,
+    };
+  }
+
+  return undefined;
+}
+
 describe('Invitations lifecycle (e2e)', () => {
   let app: INestApplication;
 
@@ -263,7 +300,7 @@ describe('Invitations lifecycle (e2e)', () => {
     canActivate(context: ExecutionContext): boolean {
       const requestContext = context.switchToHttp().getRequest<{
         headers: Record<string, string | undefined>;
-        user?: { sub: string; email: string };
+        user?: TestAuthUser;
       }>();
 
       const authorization = requestContext.headers.authorization;
@@ -271,27 +308,9 @@ describe('Invitations lifecycle (e2e)', () => {
         ? authorization.slice(7)
         : undefined;
 
-      if (token === 'organizer-token') {
-        requestContext.user = {
-          sub: users.organizer.id,
-          email: users.organizer.email,
-        };
-        return true;
-      }
-
-      if (token === 'invitee-token') {
-        requestContext.user = {
-          sub: users.invitee.id,
-          email: users.invitee.email,
-        };
-        return true;
-      }
-
-      if (token === 'stranger-token') {
-        requestContext.user = {
-          sub: users.stranger.id,
-          email: users.stranger.email,
-        };
+      const resolvedUser = resolveUserFromToken(token, users);
+      if (resolvedUser) {
+        requestContext.user = resolvedUser;
         return true;
       }
 
@@ -341,7 +360,7 @@ describe('Invitations lifecycle (e2e)', () => {
       (
         req: {
           headers: Record<string, string | string[] | undefined>;
-          user?: { sub: string; email: string };
+          user?: TestAuthUser;
         },
         _res: unknown,
         next: () => void,
@@ -352,26 +371,7 @@ describe('Invitations lifecycle (e2e)', () => {
             ? authHeader.slice(7)
             : undefined;
 
-        if (token === 'organizer-token') {
-          req.user = {
-            sub: users.organizer.id,
-            email: users.organizer.email,
-          };
-        }
-
-        if (token === 'invitee-token') {
-          req.user = {
-            sub: users.invitee.id,
-            email: users.invitee.email,
-          };
-        }
-
-        if (token === 'stranger-token') {
-          req.user = {
-            sub: users.stranger.id,
-            email: users.stranger.email,
-          };
-        }
+        req.user = resolveUserFromToken(token, users);
 
         next();
       },

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -128,6 +128,20 @@ describe('Invitations lifecycle (e2e)', () => {
     delete: jest.fn(() => ({ affected: 1 })),
   };
 
+  const transactionManager = {
+    getRepository: jest.fn((entity: unknown) => {
+      if (entity === EventInvitation) {
+        return invitationsRepository;
+      }
+
+      if (entity === Participant) {
+        return participantsRepository;
+      }
+
+      return undefined;
+    }),
+  };
+
   const invitationsRepository = {
     create: jest.fn((payload: Record<string, unknown>) => payload),
     find: jest.fn(
@@ -186,6 +200,30 @@ describe('Invitations lifecycle (e2e)', () => {
 
       return invitations[existingIndex];
     }),
+    update: jest.fn(
+      (
+        where: {
+          id: string;
+          invitedUserId: string;
+          status: EventInvitationStatus;
+        },
+        values: { status: EventInvitationStatus },
+      ) => {
+        const invitation = invitations.find(
+          (row) =>
+            row.id === where.id &&
+            row.invitedUserId === where.invitedUserId &&
+            row.status === where.status,
+        );
+
+        if (!invitation) {
+          return { affected: 0 };
+        }
+
+        invitation.status = values.status;
+        return { affected: 1 };
+      },
+    ),
     delete: jest.fn(({ id, eventId }: { id: string; eventId: string }) => {
       const index = invitations.findIndex(
         (invitation) => invitation.id === id && invitation.eventId === eventId,
@@ -197,6 +235,15 @@ describe('Invitations lifecycle (e2e)', () => {
 
       return { affected: index >= 0 ? 1 : 0 };
     }),
+    manager: {
+      transaction: jest.fn(
+        (
+          callback: (
+            manager: typeof transactionManager,
+          ) => Promise<unknown> | unknown,
+        ) => Promise.resolve(callback(transactionManager)),
+      ),
+    },
   };
 
   const usersRepository = {

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -433,7 +433,7 @@ describe('Invitations lifecycle (e2e)', () => {
     await request(httpServer)
       .post(`/invitations/${invitationToAcceptId}/accept`)
       .set('Authorization', 'Bearer invitee-token')
-      .expect(201)
+      .expect(200)
       .expect((response) => {
         expect(response.body).toEqual(
           expect.objectContaining({

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -165,20 +165,6 @@ describe('Invitations lifecycle (e2e)', () => {
     delete: jest.fn(() => ({ affected: 1 })),
   };
 
-  const transactionManager = {
-    getRepository: jest.fn((entity: unknown) => {
-      if (entity === EventInvitation) {
-        return invitationsRepository;
-      }
-
-      if (entity === Participant) {
-        return participantsRepository;
-      }
-
-      return undefined;
-    }),
-  };
-
   const invitationsRepository = {
     create: jest.fn((payload: Record<string, unknown>) => payload),
     find: jest.fn(
@@ -273,15 +259,28 @@ describe('Invitations lifecycle (e2e)', () => {
       return { affected: index >= 0 ? 1 : 0 };
     }),
     manager: {
-      transaction: jest.fn(
-        (
-          callback: (
-            manager: typeof transactionManager,
-          ) => Promise<unknown> | unknown,
-        ) => Promise.resolve(callback(transactionManager)),
-      ),
+      transaction: jest.fn(),
     },
   };
+
+  const transactionManager = {
+    getRepository: jest.fn((entity: unknown): unknown => {
+      if (entity === EventInvitation) {
+        return invitationsRepository;
+      }
+
+      if (entity === Participant) {
+        return participantsRepository;
+      }
+
+      return undefined;
+    }),
+  };
+
+  invitationsRepository.manager.transaction.mockImplementation(
+    (callback: (manager: typeof transactionManager) => unknown) =>
+      Promise.resolve(callback(transactionManager)),
+  );
 
   const usersRepository = {
     findOne: jest.fn(

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -1,0 +1,426 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { JwtAuthGuard } from '../src/auth/jwt-auth.guard';
+import { EventsController } from '../src/events/events.controller';
+import { Event, EventVisibility } from '../src/events/entities/event.entity';
+import { EventsService } from '../src/events/events.service';
+import { InvitationsLifecycleController } from '../src/invitations/invitations-lifecycle.controller';
+import { InvitationsController } from '../src/invitations/invitations.controller';
+import {
+  EventInvitation,
+  EventInvitationStatus,
+} from '../src/invitations/entities/event-invitation.entity';
+import { InvitationsService } from '../src/invitations/invitations.service';
+import { Participant } from '../src/participants/entities/participant.entity';
+import { Tag } from '../src/tags/entities/tag.entity';
+import { User } from '../src/users/entities/user.entity';
+
+type InvitationRecord = {
+  id: string;
+  eventId: string;
+  invitedByUserId: string;
+  invitedUserId: string;
+  status: EventInvitationStatus;
+  createdAt: Date;
+};
+
+describe('Invitations lifecycle (e2e)', () => {
+  let app: INestApplication;
+
+  const users = {
+    organizer: {
+      id: '11111111-1111-4111-8111-111111111111',
+      email: 'organizer@example.com',
+      name: 'Organizer',
+    },
+    invitee: {
+      id: '22222222-2222-4222-8222-222222222222',
+      email: 'invitee@example.com',
+      name: 'Invitee',
+    },
+    stranger: {
+      id: '33333333-3333-4333-8333-333333333333',
+      email: 'stranger@example.com',
+      name: 'Stranger',
+    },
+  };
+
+  const privateEventId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const invitationToAcceptId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const invitationToDeclineId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+  const invitations: InvitationRecord[] = [];
+  const participants: Array<{ id: string; eventId: string; userId: string }> =
+    [];
+
+  const eventsRepository = {
+    findOne: jest.fn(({ where }: { where: { id: string } }) => {
+      if (where.id !== privateEventId) {
+        return null;
+      }
+
+      return {
+        id: privateEventId,
+        title: 'Private party',
+        visibility: EventVisibility.PRIVATE,
+        organizerId: users.organizer.id,
+        organizer: users.organizer,
+        participants: participants.map((participant) => ({
+          userId: participant.userId,
+          user: Object.values(users).find(
+            (user) => user.id === participant.userId,
+          ),
+        })),
+        invitations: invitations.filter(
+          (invitation) => invitation.eventId === privateEventId,
+        ),
+        tags: [],
+        eventDate: new Date('2026-12-01T18:00:00.000Z'),
+      };
+    }),
+    find: jest.fn(() => []),
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    save: jest.fn((payload: Record<string, unknown>) => payload),
+    delete: jest.fn(() => ({ affected: 1 })),
+    manager: {
+      transaction: jest.fn(),
+    },
+  };
+
+  const participantsRepository = {
+    findOne: jest.fn(
+      ({ where }: { where: { eventId: string; userId: string } }) =>
+        participants.find(
+          (participant) =>
+            participant.eventId === where.eventId &&
+            participant.userId === where.userId,
+        ) ?? null,
+    ),
+    count: jest.fn(() => participants.length),
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    save: jest.fn((payload: { eventId: string; userId: string }) => {
+      const existing = participants.find(
+        (participant) =>
+          participant.eventId === payload.eventId &&
+          participant.userId === payload.userId,
+      );
+
+      if (existing) {
+        return existing;
+      }
+
+      const row = {
+        id: `participant-${participants.length + 1}`,
+        eventId: payload.eventId,
+        userId: payload.userId,
+      };
+
+      participants.push(row);
+      return row;
+    }),
+    delete: jest.fn(() => ({ affected: 1 })),
+  };
+
+  const invitationsRepository = {
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    find: jest.fn(
+      ({ where }: { where: { eventId?: string; invitedUserId?: string } }) => {
+        if (where.eventId) {
+          return invitations.filter(
+            (invitation) => invitation.eventId === where.eventId,
+          );
+        }
+
+        if (where.invitedUserId) {
+          return invitations.filter(
+            (invitation) => invitation.invitedUserId === where.invitedUserId,
+          );
+        }
+
+        return [];
+      },
+    ),
+    findOne: jest.fn(
+      ({
+        where,
+      }: {
+        where: { id?: string; eventId?: string; invitedUserId?: string };
+      }) =>
+        invitations.find((invitation) => {
+          const idMatches = where.id ? invitation.id === where.id : true;
+          const eventMatches = where.eventId
+            ? invitation.eventId === where.eventId
+            : true;
+          const userMatches = where.invitedUserId
+            ? invitation.invitedUserId === where.invitedUserId
+            : true;
+
+          return idMatches && eventMatches && userMatches;
+        }) ?? null,
+    ),
+    save: jest.fn((payload: InvitationRecord) => {
+      const existingIndex = invitations.findIndex(
+        (invitation) => invitation.id === payload.id,
+      );
+
+      if (existingIndex === -1) {
+        const row: InvitationRecord = {
+          ...payload,
+          createdAt: payload.createdAt ?? new Date(),
+        };
+        invitations.push(row);
+        return row;
+      }
+
+      invitations[existingIndex] = {
+        ...invitations[existingIndex],
+        ...payload,
+      };
+
+      return invitations[existingIndex];
+    }),
+    delete: jest.fn(({ id, eventId }: { id: string; eventId: string }) => {
+      const index = invitations.findIndex(
+        (invitation) => invitation.id === id && invitation.eventId === eventId,
+      );
+
+      if (index >= 0) {
+        invitations.splice(index, 1);
+      }
+
+      return { affected: index >= 0 ? 1 : 0 };
+    }),
+  };
+
+  const usersRepository = {
+    findOne: jest.fn(
+      ({ where }: { where: { id: string } }) =>
+        Object.values(users).find((user) => user.id === where.id) ?? null,
+    ),
+  };
+
+  const tagsRepository = {
+    find: jest.fn(() => []),
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    save: jest.fn((payload: Record<string, unknown>) => payload),
+  };
+
+  const authGuard: CanActivate = {
+    canActivate(context: ExecutionContext): boolean {
+      const requestContext = context.switchToHttp().getRequest<{
+        headers: Record<string, string | undefined>;
+        user?: { sub: string; email: string };
+      }>();
+
+      const authorization = requestContext.headers.authorization;
+      const token = authorization?.startsWith('Bearer ')
+        ? authorization.slice(7)
+        : undefined;
+
+      if (token === 'organizer-token') {
+        requestContext.user = {
+          sub: users.organizer.id,
+          email: users.organizer.email,
+        };
+        return true;
+      }
+
+      if (token === 'invitee-token') {
+        requestContext.user = {
+          sub: users.invitee.id,
+          email: users.invitee.email,
+        };
+        return true;
+      }
+
+      if (token === 'stranger-token') {
+        requestContext.user = {
+          sub: users.stranger.id,
+          email: users.stranger.email,
+        };
+        return true;
+      }
+
+      throw new UnauthorizedException();
+    },
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [
+        EventsController,
+        InvitationsController,
+        InvitationsLifecycleController,
+      ],
+      providers: [
+        EventsService,
+        InvitationsService,
+        {
+          provide: getRepositoryToken(Event),
+          useValue: eventsRepository,
+        },
+        {
+          provide: getRepositoryToken(Participant),
+          useValue: participantsRepository,
+        },
+        {
+          provide: getRepositoryToken(Tag),
+          useValue: tagsRepository,
+        },
+        {
+          provide: getRepositoryToken(EventInvitation),
+          useValue: invitationsRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepository,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(authGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.use(
+      (
+        req: {
+          headers: Record<string, string | string[] | undefined>;
+          user?: { sub: string; email: string };
+        },
+        _res: unknown,
+        next: () => void,
+      ) => {
+        const authHeader = req.headers.authorization;
+        const token =
+          typeof authHeader === 'string' && authHeader.startsWith('Bearer ')
+            ? authHeader.slice(7)
+            : undefined;
+
+        if (token === 'organizer-token') {
+          req.user = {
+            sub: users.organizer.id,
+            email: users.organizer.email,
+          };
+        }
+
+        if (token === 'invitee-token') {
+          req.user = {
+            sub: users.invitee.id,
+            email: users.invitee.email,
+          };
+        }
+
+        if (token === 'stranger-token') {
+          req.user = {
+            sub: users.stranger.id,
+            email: users.stranger.email,
+          };
+        }
+
+        next();
+      },
+    );
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    invitations.length = 0;
+    participants.length = 0;
+
+    invitations.push(
+      {
+        id: invitationToAcceptId,
+        eventId: privateEventId,
+        invitedByUserId: users.organizer.id,
+        invitedUserId: users.invitee.id,
+        status: EventInvitationStatus.PENDING,
+        createdAt: new Date('2026-10-01T10:00:00.000Z'),
+      },
+      {
+        id: invitationToDeclineId,
+        eventId: privateEventId,
+        invitedByUserId: users.organizer.id,
+        invitedUserId: users.invitee.id,
+        status: EventInvitationStatus.PENDING,
+        createdAt: new Date('2026-10-01T11:00:00.000Z'),
+      },
+    );
+
+    jest.clearAllMocks();
+  });
+
+  it('GET /invitations/me returns invitations for current user', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(httpServer)
+      .get('/invitations/me')
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(200);
+
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body).toHaveLength(2);
+  });
+
+  it('POST /invitations/:id/accept grants private event access', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(httpServer)
+      .get(`/events/${privateEventId}`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(403);
+
+    await request(httpServer)
+      .post(`/invitations/${invitationToAcceptId}/accept`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(201)
+      .expect((response) => {
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            id: invitationToAcceptId,
+            status: EventInvitationStatus.ACCEPTED,
+          }),
+        );
+      });
+
+    await request(httpServer)
+      .get(`/events/${privateEventId}`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(200);
+  });
+
+  it('POST /invitations/:id/decline sets declined status and keeps private access denied', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(httpServer)
+      .post(`/invitations/${invitationToDeclineId}/decline`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(201)
+      .expect((response) => {
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            id: invitationToDeclineId,
+            status: EventInvitationStatus.DECLINED,
+          }),
+        );
+      });
+
+    await request(httpServer)
+      .get(`/events/${privateEventId}`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(403);
+  });
+});


### PR DESCRIPTION
### What changed


- Added invitation lifecycle endpoints for authenticated users:
- GET /invitations/me
- POST /invitations/:invitationId/accept
- POST /invitations/:invitationId/decline
- Extended invitations service with lifecycle logic:
- listMyInvitations
- acceptInvitation
- declineInvitation
- On accept, invitation status is updated and participant membership is created (with unique-race handling).
- Integrated private event access with accepted invitations:
- users with accepted invitation can access private event details.
- Registered new lifecycle controller in invitations module.
- Added and expanded tests:
- unit tests for invitations lifecycle service behavior
- unit tests for lifecycle controller delegation
- events service tests for accepted-invitation private access
- e2e tests for me/accept/decline lifecycle flow and resulting access behavior

### Why


- Complete backend invitation flow beyond organizer-only management.
- Ensure private access rules include invited users after explicit acceptance.
- Make lifecycle behavior deterministic and covered by tests before frontend integration.

### Validation


- Ran unit tests:
- npm test -- invitations.service invitations.controller invitations-lifecycle.controller events.service
- Ran e2e tests:
- npm run test:e2e -- [invitations.e2e-spec.ts](vscode-file://vscode-app/c:/Users/obula/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Result: all tests passed.

### Risks/Notes


- Accept currently auto-creates participant membership by design.
- Re-invite and advanced audit/history rules remain future enhancements.
- This PR is intended to merge into feature/issue-private-invitations (not directly into main).