### PR TITLE
feat(frontend): implement private invitations ui and flows

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -10,6 +10,7 @@ import { EventDetailsPage } from "../pages/EventDetailsPage";
 import { EventsPage } from "../pages/EventsPage";
 import { LoginPage } from "../pages/LoginPage";
 import { MyEventsPage } from "../pages/MyEventsPage";
+import { MyInvitationsPage } from "../pages/MyInvitationsPage";
 import { RegisterPage } from "../pages/RegisterPage";
 import { APP_ROUTES } from "./routes";
 
@@ -50,6 +51,14 @@ const appRoutes = [
         element: (
           <ProtectedRoute>
             <MyEventsPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: APP_ROUTES.myInvitations,
+        element: (
+          <ProtectedRoute>
+            <MyInvitationsPage />
           </ProtectedRoute>
         ),
       },

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -4,6 +4,7 @@ export const APP_ROUTES = {
   eventDetails: "/events/:id",
   createEvent: "/events/create",
   myEvents: "/my-events",
+  myInvitations: "/my-invitations",
   login: "/login",
   register: "/register",
   wildcard: "*",

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,14 +1,15 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { authReducer } from "../features/auth/authSlice";
 import { eventsReducer } from "../features/events/model/eventsSlice";
+import { invitationsReducer } from "../features/invitations/model/invitationsSlice";
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     events: eventsReducer,
+    invitations: invitationsReducer,
   },
 });
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
-

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -25,6 +25,7 @@ export function MainLayout() {
     (pathname.startsWith("/events/") && pathname !== "/events/create");
   const isCreateActive = pathname === "/events/create";
   const isMyEventsActive = pathname === "/my-events";
+  const isMyInvitationsActive = pathname === "/my-invitations";
 
   const navItemClass = (isActive: boolean) =>
     isActive
@@ -163,6 +164,39 @@ export function MainLayout() {
                 <path d="M3 10H21" stroke="currentColor" strokeWidth="2" />
               </svg>
               My Events
+            </Link>
+            <Link
+              to="/my-invitations"
+              className={navItemClass(isMyInvitationsActive)}
+            >
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 7H20"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+                <path
+                  d="M4 12H20"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+                <path
+                  d="M4 17H14"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+              </svg>
+              My Invitations
             </Link>
             <Link
               to="/events/create"

--- a/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
+++ b/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
@@ -11,6 +11,7 @@ import { EditIcon } from "../../../../components/ui/icons/EditIcon";
 import { TrashIcon } from "../../../../components/ui/icons/TrashIcon";
 import { EventEditForm } from "./EventEditForm";
 import type { EventEditFormValues } from "./EventEditForm";
+import { OrganizerInvitationsPanel } from "../../../invitations/ui/OrganizerInvitationsPanel";
 
 type EventDetailsInteractionSectionProps = {
   currentEvent: EventItem;
@@ -270,6 +271,12 @@ export function EventDetailsInteractionSection({
       </div>
 
       {error ? <FormErrorText className="mt-4">{error}</FormErrorText> : null}
+
+      <OrganizerInvitationsPanel
+        eventId={currentEvent.id}
+        isPrivateEvent={currentEvent.visibility === "private"}
+        isOrganizer={isOrganizer}
+      />
 
       {isOrganizer && isEditing ? (
         <EventEditForm

--- a/frontend/src/features/invitations/api/invitationsApi.ts
+++ b/frontend/src/features/invitations/api/invitationsApi.ts
@@ -1,0 +1,63 @@
+import { api } from "../../../shared/api/client";
+import type { InvitationItem } from "../../../types/invitation";
+
+export const fetchEventInvitationsRequest = async (
+  eventId: string,
+): Promise<InvitationItem[]> => {
+  const response = await api.get<InvitationItem[]>(
+    `/events/${eventId}/invitations`,
+  );
+  return response.data;
+};
+
+export const createInvitationRequest = async (payload: {
+  eventId: string;
+  invitedUserId: string;
+}): Promise<InvitationItem> => {
+  const response = await api.post<InvitationItem>(
+    `/events/${payload.eventId}/invitations`,
+    {
+      invitedUserId: payload.invitedUserId,
+    },
+  );
+
+  return response.data;
+};
+
+export const revokeInvitationRequest = async (payload: {
+  eventId: string;
+  invitationId: string;
+}): Promise<void> => {
+  await api.delete(
+    `/events/${payload.eventId}/invitations/${payload.invitationId}`,
+  );
+};
+
+export const fetchMyInvitationsRequest = async (): Promise<
+  InvitationItem[]
+> => {
+  const response = await api.get<InvitationItem[]>("/invitations/me");
+  return response.data;
+};
+
+export const acceptInvitationRequest = async (
+  invitationId: string,
+): Promise<InvitationItem> => {
+  const response = await api.post<InvitationItem>(
+    `/invitations/${invitationId}/accept`,
+    {},
+  );
+
+  return response.data;
+};
+
+export const declineInvitationRequest = async (
+  invitationId: string,
+): Promise<InvitationItem> => {
+  const response = await api.post<InvitationItem>(
+    `/invitations/${invitationId}/decline`,
+    {},
+  );
+
+  return response.data;
+};

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -131,6 +131,7 @@ const invitationsSlice = createSlice({
           current,
           action.payload.invitation,
         );
+        state.eventErrorById[action.payload.eventId] = null;
       })
       .addCase(createInvitation.rejected, (state, action) => {
         state.actionStatusByKey[`create:${action.meta.arg.eventId}`] = "failed";
@@ -148,6 +149,7 @@ const invitationsSlice = createSlice({
         state.byEventId[action.payload.eventId] = current.filter(
           (invitation) => invitation.id !== action.payload.invitationId,
         );
+        state.eventErrorById[action.payload.eventId] = null;
       })
       .addCase(revokeInvitation.rejected, (state, action) => {
         state.actionStatusByKey[`revoke:${action.meta.arg.invitationId}`] =

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -12,11 +12,11 @@ import {
 
 type InvitationsState = {
   byEventId: Record<string, InvitationItem[]>;
-  eventStatusById: Record<string, "idle" | "loading" | "failed">;
+  eventStatusById: Partial<Record<string, "idle" | "loading" | "failed">>;
   myInvitations: InvitationItem[];
   myStatus: "idle" | "loading" | "failed";
-  actionStatusByKey: Record<string, "idle" | "loading" | "failed">;
-  eventErrorById: Record<string, string | null>;
+  actionStatusByKey: Partial<Record<string, "idle" | "loading" | "failed">>;
+  eventErrorById: Partial<Record<string, string | null>>;
   myError: string | null;
   actionError: string | null;
 };

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -107,10 +107,12 @@ const invitationsSlice = createSlice({
       .addCase(fetchInvitationsForEvent.pending, (state, action) => {
         state.eventStatusById[action.meta.arg] = "loading";
         state.eventErrorById[action.meta.arg] = null;
+        state.actionError = null; // Clear global action error on event invitations load
       })
       .addCase(fetchInvitationsForEvent.fulfilled, (state, action) => {
         state.eventStatusById[action.payload.eventId] = "idle";
         state.byEventId[action.payload.eventId] = action.payload.invitations;
+        state.actionError = null; // Also clear error after successful load
       })
       .addCase(fetchInvitationsForEvent.rejected, (state, action) => {
         const eventId = action.meta.arg;

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -1,0 +1,200 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { logoutUser } from "../../auth/authSlice";
+import type { InvitationItem } from "../../../types/invitation";
+import {
+  acceptInvitationRequest,
+  createInvitationRequest,
+  declineInvitationRequest,
+  fetchEventInvitationsRequest,
+  fetchMyInvitationsRequest,
+  revokeInvitationRequest,
+} from "../api/invitationsApi";
+
+type InvitationsState = {
+  byEventId: Record<string, InvitationItem[]>;
+  eventStatusById: Record<string, "idle" | "loading" | "failed">;
+  myInvitations: InvitationItem[];
+  myStatus: "idle" | "loading" | "failed";
+  actionStatusByKey: Record<string, "idle" | "loading" | "failed">;
+  eventErrorById: Record<string, string | null>;
+  myError: string | null;
+  actionError: string | null;
+};
+
+const initialState: InvitationsState = {
+  byEventId: {},
+  eventStatusById: {},
+  myInvitations: [],
+  myStatus: "idle",
+  actionStatusByKey: {},
+  eventErrorById: {},
+  myError: null,
+  actionError: null,
+};
+
+const upsertInvitation = (
+  invitations: InvitationItem[],
+  invitation: InvitationItem,
+): InvitationItem[] => {
+  const existingIndex = invitations.findIndex(
+    (item) => item.id === invitation.id,
+  );
+
+  if (existingIndex === -1) {
+    return [invitation, ...invitations];
+  }
+
+  const next = [...invitations];
+  next[existingIndex] = invitation;
+  return next;
+};
+
+export const fetchInvitationsForEvent = createAsyncThunk(
+  "invitations/fetchForEvent",
+  async (eventId: string) => {
+    const invitations = await fetchEventInvitationsRequest(eventId);
+    return { eventId, invitations };
+  },
+);
+
+export const createInvitation = createAsyncThunk(
+  "invitations/create",
+  async (payload: { eventId: string; invitedUserId: string }) => {
+    const invitation = await createInvitationRequest(payload);
+    return {
+      eventId: payload.eventId,
+      invitation,
+    };
+  },
+);
+
+export const revokeInvitation = createAsyncThunk(
+  "invitations/revoke",
+  async (payload: { eventId: string; invitationId: string }) => {
+    await revokeInvitationRequest(payload);
+    return payload;
+  },
+);
+
+export const fetchMyInvitations = createAsyncThunk(
+  "invitations/fetchMy",
+  async () => {
+    return fetchMyInvitationsRequest();
+  },
+);
+
+export const acceptInvitation = createAsyncThunk(
+  "invitations/accept",
+  async (invitationId: string) => {
+    return acceptInvitationRequest(invitationId);
+  },
+);
+
+export const declineInvitation = createAsyncThunk(
+  "invitations/decline",
+  async (invitationId: string) => {
+    return declineInvitationRequest(invitationId);
+  },
+);
+
+const invitationsSlice = createSlice({
+  name: "invitations",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(logoutUser.fulfilled, () => initialState)
+      .addCase(fetchInvitationsForEvent.pending, (state, action) => {
+        state.eventStatusById[action.meta.arg] = "loading";
+        state.eventErrorById[action.meta.arg] = null;
+      })
+      .addCase(fetchInvitationsForEvent.fulfilled, (state, action) => {
+        state.eventStatusById[action.payload.eventId] = "idle";
+        state.byEventId[action.payload.eventId] = action.payload.invitations;
+      })
+      .addCase(fetchInvitationsForEvent.rejected, (state, action) => {
+        const eventId = action.meta.arg;
+        state.eventStatusById[eventId] = "failed";
+        state.eventErrorById[eventId] = "Failed to load invitations";
+      })
+      .addCase(createInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`create:${action.meta.arg.eventId}`] =
+          "loading";
+        state.actionError = null;
+      })
+      .addCase(createInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`create:${action.payload.eventId}`] = "idle";
+        const current = state.byEventId[action.payload.eventId] ?? [];
+        state.byEventId[action.payload.eventId] = upsertInvitation(
+          current,
+          action.payload.invitation,
+        );
+      })
+      .addCase(createInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`create:${action.meta.arg.eventId}`] = "failed";
+        state.actionError = "Failed to create invitation";
+      })
+      .addCase(revokeInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`revoke:${action.meta.arg.invitationId}`] =
+          "loading";
+        state.actionError = null;
+      })
+      .addCase(revokeInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`revoke:${action.payload.invitationId}`] =
+          "idle";
+        const current = state.byEventId[action.payload.eventId] ?? [];
+        state.byEventId[action.payload.eventId] = current.filter(
+          (invitation) => invitation.id !== action.payload.invitationId,
+        );
+      })
+      .addCase(revokeInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`revoke:${action.meta.arg.invitationId}`] =
+          "failed";
+        state.actionError = "Failed to revoke invitation";
+      })
+      .addCase(fetchMyInvitations.pending, (state) => {
+        state.myStatus = "loading";
+        state.myError = null;
+      })
+      .addCase(fetchMyInvitations.fulfilled, (state, action) => {
+        state.myStatus = "idle";
+        state.myInvitations = action.payload;
+      })
+      .addCase(fetchMyInvitations.rejected, (state) => {
+        state.myStatus = "failed";
+        state.myError = "Failed to load my invitations";
+      })
+      .addCase(acceptInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "loading";
+        state.actionError = null;
+      })
+      .addCase(acceptInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`respond:${action.payload.id}`] = "idle";
+        state.myInvitations = upsertInvitation(
+          state.myInvitations,
+          action.payload,
+        );
+      })
+      .addCase(acceptInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "failed";
+        state.actionError = "Failed to accept invitation";
+      })
+      .addCase(declineInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "loading";
+        state.actionError = null;
+      })
+      .addCase(declineInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`respond:${action.payload.id}`] = "idle";
+        state.myInvitations = upsertInvitation(
+          state.myInvitations,
+          action.payload,
+        );
+      })
+      .addCase(declineInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "failed";
+        state.actionError = "Failed to decline invitation";
+      });
+  },
+});
+
+export const invitationsReducer = invitationsSlice.reducer;

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -107,10 +107,12 @@ const invitationsSlice = createSlice({
       .addCase(fetchInvitationsForEvent.pending, (state, action) => {
         state.eventStatusById[action.meta.arg] = "loading";
         state.eventErrorById[action.meta.arg] = null;
+        state.actionError = null; // Clear global action error on event invitations load
       })
       .addCase(fetchInvitationsForEvent.fulfilled, (state, action) => {
         state.eventStatusById[action.payload.eventId] = "idle";
         state.byEventId[action.payload.eventId] = action.payload.invitations;
+        state.actionError = null; // Also clear error after successful load
       })
       .addCase(fetchInvitationsForEvent.rejected, (state, action) => {
         const eventId = action.meta.arg;
@@ -155,6 +157,7 @@ const invitationsSlice = createSlice({
       .addCase(fetchMyInvitations.pending, (state) => {
         state.myStatus = "loading";
         state.myError = null;
+        state.actionError = null; // Clear global action error on my invitations load
       })
       .addCase(fetchMyInvitations.fulfilled, (state, action) => {
         state.myStatus = "idle";

--- a/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
+++ b/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
@@ -90,7 +90,7 @@ export function OrganizerInvitationsPanel({
           onChange={(event) => setInvitedUserId(event.target.value)}
           type="text"
           placeholder="Invited user UUID"
-          className="min-w-70 flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+          className="min-w-[17.5rem] flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
         />
         <Button
           type="submit"

--- a/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
+++ b/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
@@ -41,6 +41,7 @@ export function OrganizerInvitationsPanel({
     (state) =>
       state.invitations.actionStatusByKey[`create:${eventId}`] === "loading",
   );
+  const inviteInputId = `invited-user-id-${eventId}`;
   const [invitedUserId, setInvitedUserId] = useState("");
 
   useEffect(() => {
@@ -85,7 +86,11 @@ export function OrganizerInvitationsPanel({
         onSubmit={(event) => void handleInvite(event)}
         className="mt-4 flex flex-wrap gap-2"
       >
+        <label htmlFor={inviteInputId} className="sr-only">
+          Invited user UUID
+        </label>
         <input
+          id={inviteInputId}
           value={invitedUserId}
           onChange={(event) => setInvitedUserId(event.target.value)}
           type="text"
@@ -112,7 +117,7 @@ export function OrganizerInvitationsPanel({
         <FormErrorText className="mt-2">{actionError}</FormErrorText>
       ) : null}
 
-      {invitations.length === 0 && listStatus !== "loading" ? (
+      {listStatus === "idle" && !listError && invitations.length === 0 ? (
         <p className="mt-4 text-sm text-slate-600">No invitations yet.</p>
       ) : null}
 

--- a/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
+++ b/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import { useAppDispatch, useAppSelector } from "../../../app/hooks";
+import {
+  createInvitation,
+  fetchInvitationsForEvent,
+  revokeInvitation,
+} from "../model/invitationsSlice";
+import { Button } from "../../../components/ui/Button";
+import { FormErrorText } from "../../../components/ui/FormErrorText";
+import type { InvitationItem } from "../../../types/invitation";
+
+type OrganizerInvitationsPanelProps = {
+  eventId: string;
+  isPrivateEvent: boolean;
+  isOrganizer: boolean;
+};
+
+const EMPTY_INVITATIONS: InvitationItem[] = [];
+
+export function OrganizerInvitationsPanel({
+  eventId,
+  isPrivateEvent,
+  isOrganizer,
+}: OrganizerInvitationsPanelProps) {
+  const dispatch = useAppDispatch();
+  const invitations = useAppSelector(
+    (state) => state.invitations.byEventId[eventId] ?? EMPTY_INVITATIONS,
+  );
+  const listStatus = useAppSelector(
+    (state) => state.invitations.eventStatusById[eventId] ?? "idle",
+  );
+  const listError = useAppSelector(
+    (state) => state.invitations.eventErrorById[eventId],
+  );
+  const actionError = useAppSelector((state) => state.invitations.actionError);
+  const actionStatusByKey = useAppSelector(
+    (state) => state.invitations.actionStatusByKey,
+  );
+  const isCreating = useAppSelector(
+    (state) =>
+      state.invitations.actionStatusByKey[`create:${eventId}`] === "loading",
+  );
+  const [invitedUserId, setInvitedUserId] = useState("");
+
+  useEffect(() => {
+    if (isOrganizer && isPrivateEvent) {
+      void dispatch(fetchInvitationsForEvent(eventId));
+    }
+  }, [dispatch, eventId, isOrganizer, isPrivateEvent]);
+
+  const handleInvite = async (submitEvent: FormEvent<HTMLFormElement>) => {
+    submitEvent.preventDefault();
+
+    const nextUserId = invitedUserId.trim();
+    if (!nextUserId) {
+      return;
+    }
+
+    try {
+      await dispatch(
+        createInvitation({
+          eventId,
+          invitedUserId: nextUserId,
+        }),
+      ).unwrap();
+      setInvitedUserId("");
+    } catch {
+      // Error state is handled by Redux slice for consistent UX.
+    }
+  };
+
+  if (!isOrganizer || !isPrivateEvent) {
+    return null;
+  }
+
+  return (
+    <section className="mt-8 rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <h3 className="text-lg font-semibold text-slate-900">Invitations</h3>
+      <p className="mt-1 text-sm text-slate-600">
+        Invite users by their account UUID to join this private event.
+      </p>
+
+      <form
+        onSubmit={(event) => void handleInvite(event)}
+        className="mt-4 flex flex-wrap gap-2"
+      >
+        <input
+          value={invitedUserId}
+          onChange={(event) => setInvitedUserId(event.target.value)}
+          type="text"
+          placeholder="Invited user UUID"
+          className="min-w-70 flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+        />
+        <Button
+          type="submit"
+          disabled={isCreating || invitedUserId.trim().length === 0}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-60"
+        >
+          {isCreating ? "Inviting..." : "Invite"}
+        </Button>
+      </form>
+
+      {listStatus === "loading" ? (
+        <p className="mt-4 text-sm text-slate-600">Loading invitations...</p>
+      ) : null}
+
+      {listError ? (
+        <FormErrorText className="mt-3">{listError}</FormErrorText>
+      ) : null}
+      {actionError ? (
+        <FormErrorText className="mt-2">{actionError}</FormErrorText>
+      ) : null}
+
+      {invitations.length === 0 && listStatus !== "loading" ? (
+        <p className="mt-4 text-sm text-slate-600">No invitations yet.</p>
+      ) : null}
+
+      {invitations.length > 0 ? (
+        <ul className="mt-4 space-y-2">
+          {invitations.map((invitation) => {
+            const isRevoking =
+              actionStatusByKey[`revoke:${invitation.id}`] === "loading";
+
+            return (
+              <li
+                key={invitation.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2"
+              >
+                <div className="text-sm text-slate-800">
+                  <span className="font-medium">
+                    {invitation.invitedUser?.email ?? invitation.invitedUserId}
+                  </span>
+                  <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs uppercase text-slate-600">
+                    {invitation.status}
+                  </span>
+                </div>
+                <Button
+                  type="button"
+                  disabled={isRevoking}
+                  onClick={() => {
+                    void dispatch(
+                      revokeInvitation({
+                        eventId,
+                        invitationId: invitation.id,
+                      }),
+                    );
+                  }}
+                  className="rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-700 hover:bg-red-100 disabled:opacity-60"
+                >
+                  {isRevoking ? "Revoking..." : "Revoke"}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/EventDetailsPage.test.tsx
+++ b/frontend/src/pages/EventDetailsPage.test.tsx
@@ -299,4 +299,80 @@ describe("EventDetailsPage", () => {
       resolveDelete?.();
     });
   });
+
+  it("shows organizer invitations panel for private event and submits invite", async () => {
+    const event = {
+      ...createInitialEvent(),
+      visibility: "private" as const,
+    };
+
+    vi.spyOn(api, "get").mockImplementation(async (url: string) => {
+      if (url === "/events/evt-1") {
+        return { data: event };
+      }
+
+      if (url === "/users/me/events") {
+        return { data: [] };
+      }
+
+      if (url === "/events/evt-1/invitations") {
+        return { data: [] };
+      }
+
+      throw new Error(`Unexpected GET url: ${url}`);
+    });
+
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      data: {
+        id: "inv-1",
+        eventId: "evt-1",
+        invitedByUserId: "org-1",
+        invitedUserId: "usr-2",
+        status: "pending",
+        createdAt: "2099-01-01T00:00:00.000Z",
+      },
+    });
+
+    const store = createTestStore({
+      auth: {
+        token: "test-token",
+        user: { email: "organizer@example.com" },
+        status: "idle",
+        error: null,
+      },
+      events: {
+        publicEvents: [],
+        myEvents: [],
+        selectedEvent: null,
+        status: "idle",
+        error: null,
+        assistantAnswer: null,
+        assistantStatus: "idle",
+        assistantError: null,
+      },
+    });
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/events/evt-1"]}>
+        <Routes>
+          <Route path="/events/:id" element={<EventDetailsPage />} />
+        </Routes>
+      </MemoryRouter>,
+      { store },
+    );
+
+    expect(await screen.findByText("Invitations")).toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Invited user UUID"),
+      "usr-2",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/events/evt-1/invitations", {
+        invitedUserId: "usr-2",
+      });
+    });
+  });
 });

--- a/frontend/src/pages/MyInvitationsPage.test.tsx
+++ b/frontend/src/pages/MyInvitationsPage.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { screen, waitFor } from "@testing-library/react";
+import { api } from "../shared/api/client";
+import { MyInvitationsPage } from "./MyInvitationsPage";
+import {
+  createTestStore,
+  renderWithProviders,
+} from "../test/renderWithProviders";
+
+describe("MyInvitationsPage", () => {
+  it("loads invitations and allows accepting pending invitation", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      data: [
+        {
+          id: "inv-1",
+          eventId: "evt-1",
+          invitedByUserId: "org-1",
+          invitedUserId: "usr-1",
+          status: "pending",
+          createdAt: "2099-01-01T00:00:00.000Z",
+          invitedByUser: { id: "org-1", email: "organizer@example.com" },
+          event: {
+            id: "evt-1",
+            title: "Private meetup",
+            eventDate: "2099-01-10T10:00:00.000Z",
+            visibility: "private",
+            organizerId: "org-1",
+          },
+        },
+      ],
+    });
+
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      data: {
+        id: "inv-1",
+        eventId: "evt-1",
+        invitedByUserId: "org-1",
+        invitedUserId: "usr-1",
+        status: "accepted",
+        createdAt: "2099-01-01T00:00:00.000Z",
+        invitedByUser: { id: "org-1", email: "organizer@example.com" },
+        event: {
+          id: "evt-1",
+          title: "Private meetup",
+          eventDate: "2099-01-10T10:00:00.000Z",
+          visibility: "private",
+          organizerId: "org-1",
+        },
+      },
+    });
+
+    const store = createTestStore({
+      auth: {
+        token: "token",
+        user: { email: "invitee@example.com" },
+        status: "idle",
+        error: null,
+        isAuthenticated: true,
+        isInitialized: true,
+      },
+      events: {
+        publicEvents: [],
+        myEvents: [],
+        selectedEvent: null,
+        status: "idle",
+        error: null,
+        assistantAnswer: null,
+        assistantStatus: "idle",
+        assistantError: null,
+      },
+    });
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/my-invitations"]}>
+        <Routes>
+          <Route path="/my-invitations" element={<MyInvitationsPage />} />
+        </Routes>
+      </MemoryRouter>,
+      { store },
+    );
+
+    expect(await screen.findByText("Private meetup")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/invitations/inv-1/accept", {});
+    });
+
+    expect(screen.getByText("accepted")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MyInvitationsPage.test.tsx
+++ b/frontend/src/pages/MyInvitationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { screen, waitFor } from "@testing-library/react";
@@ -10,6 +10,10 @@ import {
 } from "../test/renderWithProviders";
 
 describe("MyInvitationsPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("loads invitations and allows accepting pending invitation", async () => {
     vi.spyOn(api, "get").mockResolvedValue({
       data: [

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useAppDispatch, useAppSelector } from "../app/hooks";
+import {
+  acceptInvitation,
+  declineInvitation,
+  fetchMyInvitations,
+} from "../features/invitations/model/invitationsSlice";
+import { Button } from "../components/ui/Button";
+import { FormErrorText } from "../components/ui/FormErrorText";
+
+export function MyInvitationsPage() {
+  const dispatch = useAppDispatch();
+  const invitations = useAppSelector(
+    (state) => state.invitations.myInvitations,
+  );
+  const status = useAppSelector((state) => state.invitations.myStatus);
+  const error = useAppSelector((state) => state.invitations.myError);
+  const actionError = useAppSelector((state) => state.invitations.actionError);
+  const actionStatusByKey = useAppSelector(
+    (state) => state.invitations.actionStatusByKey,
+  );
+
+  useEffect(() => {
+    void dispatch(fetchMyInvitations());
+  }, [dispatch]);
+
+  return (
+    <section>
+      <h2 className="text-4xl font-bold text-slate-900">My Invitations</h2>
+      <p className="mt-2 text-lg text-slate-600">
+        Review your pending invites and decide whether to join private events.
+      </p>
+
+      {status === "loading" ? (
+        <p className="mt-6 text-slate-700">Loading invitations...</p>
+      ) : null}
+      {error ? <FormErrorText className="mt-6">{error}</FormErrorText> : null}
+      {actionError ? (
+        <FormErrorText className="mt-4">{actionError}</FormErrorText>
+      ) : null}
+
+      {status !== "loading" && invitations.length === 0 ? (
+        <p className="mt-6 text-slate-600">No invitations yet.</p>
+      ) : null}
+
+      {invitations.length > 0 ? (
+        <ul className="mt-6 space-y-3">
+          {invitations.map((invitation) => {
+            const isBusy =
+              actionStatusByKey[`respond:${invitation.id}`] === "loading";
+
+            const eventTitle = invitation.event?.title ?? "Private event";
+            const eventDate = invitation.event?.eventDate
+              ? new Date(invitation.event.eventDate).toLocaleString()
+              : "Date hidden until accepted";
+            const eventLocation =
+              invitation.event?.location ?? "Location hidden until accepted";
+
+            return (
+              <li
+                key={invitation.id}
+                className="rounded-xl border border-slate-200 bg-white p-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      {eventTitle}
+                    </h3>
+                    <p className="text-sm text-slate-600">{eventDate}</p>
+                    <p className="text-sm text-slate-600">{eventLocation}</p>
+                  </div>
+                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase text-slate-700">
+                    {invitation.status}
+                  </span>
+                </div>
+
+                <p className="mt-2 text-sm text-slate-600">
+                  Invited by:{" "}
+                  {invitation.invitedByUser?.email ??
+                    invitation.invitedByUserId}
+                </p>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {invitation.status === "pending" ? (
+                    <>
+                      <Button
+                        type="button"
+                        disabled={isBusy}
+                        onClick={() => {
+                          void dispatch(acceptInvitation(invitation.id));
+                        }}
+                        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 disabled:opacity-60"
+                      >
+                        {isBusy ? "Processing..." : "Accept"}
+                      </Button>
+                      <Button
+                        type="button"
+                        disabled={isBusy}
+                        onClick={() => {
+                          void dispatch(declineInvitation(invitation.id));
+                        }}
+                        className="rounded-lg border border-slate-300 bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 disabled:opacity-60"
+                      >
+                        {isBusy ? "Processing..." : "Decline"}
+                      </Button>
+                    </>
+                  ) : null}
+
+                  {invitation.event?.id ? (
+                    <Link
+                      to={`/events/${invitation.event.id}`}
+                      className="rounded-lg border border-indigo-300 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100"
+                    >
+                      Open event
+                    </Link>
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -107,9 +107,9 @@ export function MyInvitationsPage() {
                     </>
                   ) : null}
 
-                  {invitation.event?.id ? (
+                  {invitation.status === "accepted" && invitation.eventId ? (
                     <Link
-                      to={`/events/${invitation.event.id}`}
+                      to={`/events/${invitation.eventId}`}
                       className="rounded-lg border border-indigo-300 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100"
                     >
                       Open event

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -53,7 +53,7 @@ export function MyInvitationsPage() {
             const eventTitle = invitation.event?.title ?? "Private event";
             const eventDate = invitation.event?.eventDate
               ? new Date(invitation.event.eventDate).toLocaleString()
-              : "Date hidden until accepted";
+              : "Date unavailable";
             const eventLocation =
               invitation.event?.location ?? "Location hidden until accepted";
 

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -40,7 +40,7 @@ export function MyInvitationsPage() {
         <FormErrorText className="mt-4">{actionError}</FormErrorText>
       ) : null}
 
-      {status !== "loading" && invitations.length === 0 ? (
+      {status === "idle" && !error && invitations.length === 0 ? (
         <p className="mt-6 text-slate-600">No invitations yet.</p>
       ) : null}
 

--- a/frontend/src/test/renderWithProviders.tsx
+++ b/frontend/src/test/renderWithProviders.tsx
@@ -4,10 +4,12 @@ import { configureStore } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { authReducer } from "../features/auth/authSlice";
 import { eventsReducer } from "../features/events/model/eventsSlice";
+import { invitationsReducer } from "../features/invitations/model/invitationsSlice";
 
 type TestState = {
   auth: ReturnType<typeof authReducer>;
   events: ReturnType<typeof eventsReducer>;
+  invitations: ReturnType<typeof invitationsReducer>;
 };
 
 export const createTestStore = (preloadedState?: Partial<TestState>) =>
@@ -15,6 +17,7 @@ export const createTestStore = (preloadedState?: Partial<TestState>) =>
     reducer: {
       auth: authReducer,
       events: eventsReducer,
+      invitations: invitationsReducer,
     },
     preloadedState: preloadedState as TestState | undefined,
   });
@@ -38,4 +41,3 @@ export const renderWithProviders = (
     ...render(ui, { wrapper: Wrapper }),
   };
 };
-

--- a/frontend/src/types/invitation.ts
+++ b/frontend/src/types/invitation.ts
@@ -1,0 +1,15 @@
+import type { EventItem, EventUser } from "./event";
+
+export type InvitationStatus = "pending" | "accepted" | "declined";
+
+export type InvitationItem = {
+  id: string;
+  eventId: string;
+  invitedByUserId: string;
+  invitedUserId: string;
+  status: InvitationStatus;
+  createdAt: string;
+  event?: EventItem;
+  invitedByUser?: EventUser;
+  invitedUser?: EventUser;
+};


### PR DESCRIPTION
What changed
- Added invitations API client for organizer and invitee flows:
  - list/create/revoke event invitations
  - fetch my invitations
  - accept/decline invitation
- Added invitations state management in Redux (statuses, errors, action state).
- Added organizer Invitations panel in private event details:
  - invite by user UUID
  - view current invitations
  - revoke invitation
- Added new protected page: My Invitations:
  - list invitations
  - accept/decline actions with loading/error states
  - open related event
- Integrated invitations feature into app store, routes, navigation, and test store utilities.
- Added frontend tests for invitations flows:
  - My Invitations accept flow
  - Organizer invitations panel submit flow in event details

Why
- Deliver private invitations UX end-to-end for both organizers and invitees.
- Align frontend behavior with backend invitation lifecycle and access model.
- Provide clear UI states for async invitation actions.

Validation
- Ran frontend test suite: npm run test:run
- Result: 44/44 tests passed.

Risks/Notes
- Organizer invite input currently expects a user UUID (no user search/autocomplete yet).
- UX relies on backend privacy gating for private event details in invitation payloads.