### PR TITLE
feat: merge private invitations workstream into main

### DIFF
--- a/.github/skills/github-delivery-workflow/SKILL.md
+++ b/.github/skills/github-delivery-workflow/SKILL.md
@@ -80,6 +80,23 @@ Field-specific formatting:
   - Risks/Notes
 - Comment: actionable, context-specific, no filler.
 
+## PR Review Reply Rule
+
+After implementing any PR review comment, always provide a short English reply text that is ready to paste into the review thread.
+
+Format guidance:
+
+1. Keep it to 1-3 sentences.
+2. Mention what was changed.
+3. Mention validation briefly when relevant (for example, tests run).
+4. Avoid extra context not needed by reviewer.
+
+Template:
+
+Updated based on your feedback.
+I reused the shared helper to centralize the post-update fetch and remove duplicated not-found handling in both paths.
+Validated with targeted unit/e2e tests.
+
 ## Templates
 
 Title

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Main capabilities:
 - user registration and login
 - browsing public events
 - controlled access to private events
+- organizer-managed private invitations (invite, list, revoke)
+- invitee-managed invitation responses (accept, decline) via `My Invitations`
 - creating, editing, and deleting organizer-owned events
 - joining and leaving events
 - calendar-based `My Events` view
@@ -109,6 +111,7 @@ The project is split into a React frontend and a NestJS backend.
 - frontend is responsible for routing, forms, UI state, and user interactions
 - backend is responsible for validation, authorization, persistence, and business rules
 - PostgreSQL stores users, events, participants, and tags
+- PostgreSQL stores users, events, participants, invitations, and tags
 
 ### Frontend Architecture
 
@@ -150,12 +153,14 @@ Core entities:
 - `User` organizes events and can join events
 - `Event` stores title, date, location, visibility, capacity, organizer, and tags
 - `Participant` is the explicit join table for user-event participation
+- `EventInvitation` tracks organizer-to-user private event invitations and statuses
 - `Tag` supports event categorization and frontend filtering
 
 Important constraints:
 
 - user emails are unique
 - user-event participation pairs are unique
+- event-user invitation pairs are unique
 - private events are visible only to organizer or participant
 - participant email addresses are hidden in event detail responses
 
@@ -165,6 +170,8 @@ The app uses JWT-based authentication.
 
 - protected actions such as create, update, delete, join, and leave require authenticated users
 - organizer-only actions are checked on the backend
+- invitation-management actions for private events are organizer-only
+- invitation response actions are limited to the invited user
 - private event access is validated on the backend even if the frontend hides restricted UI
 - one read route uses optional auth middleware so event details can serve both guests and signed-in users with different access levels
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,7 @@ Main responsibilities:
 - public and private event access control
 - event CRUD operations
 - join and leave flows
+- private invitation lifecycle (create, list, revoke, accept, decline)
 - calendar data for authenticated users
 - assistant endpoints for event-related questions
 
@@ -115,6 +116,18 @@ This covers:
 - fallback behavior for unsupported or unclear intents
 - read-only assistant restrictions
 - date and scope-related assistant queries
+
+Focused invitations suites:
+
+```bash
+npm run test -- invitations.service.spec.ts invitations.controller.spec.ts
+```
+
+This covers:
+
+- organizer-only invitation management rules for private events
+- invitee-only accept/decline flows
+- invitee-facing payload sanitization and response consistency
 
 ## Seeding
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { EventsModule } from './events/events.module';
 import { AuthMiddleware } from './auth/auth.middleware';
 import { AssistantModule } from './assistant/assistant.module';
 import { CsrfProtectionGuard } from './auth/csrf-protection.guard';
+import { InvitationsModule } from './invitations/invitations.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { CsrfProtectionGuard } from './auth/csrf-protection.guard';
     UsersModule,
     EventsModule,
     AssistantModule,
+    InvitationsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/database/tables-relations.spec.ts
+++ b/backend/src/database/tables-relations.spec.ts
@@ -5,6 +5,7 @@ import { User } from '../users/entities/user.entity';
 import { Event } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { Tag } from '../tags/entities/tag.entity';
+import { EventInvitation } from '../invitations/entities/event-invitation.entity';
 
 describe('Database tables relations', () => {
   let dataSource: DataSource;
@@ -12,6 +13,7 @@ describe('Database tables relations', () => {
   let eventsRepository: Repository<Event>;
   let participantsRepository: Repository<Participant>;
   let tagsRepository: Repository<Tag>;
+  let invitationsRepository: Repository<EventInvitation>;
 
   beforeAll(async () => {
     const db = newDb({ autoCreateForeignKeyIndices: true });
@@ -37,7 +39,7 @@ describe('Database tables relations', () => {
 
     dataSource = await db.adapters.createTypeormDataSource({
       type: 'postgres',
-      entities: [User, Event, Participant, Tag],
+      entities: [User, Event, Participant, Tag, EventInvitation],
       synchronize: true,
     });
 
@@ -52,6 +54,7 @@ describe('Database tables relations', () => {
     eventsRepository = dataSource.getRepository(Event);
     participantsRepository = dataSource.getRepository(Participant);
     tagsRepository = dataSource.getRepository(Tag);
+    invitationsRepository = dataSource.getRepository(EventInvitation);
   });
 
   afterAll(async () => {
@@ -63,6 +66,7 @@ describe('Database tables relations', () => {
   beforeEach(async () => {
     // Clear join table first to satisfy FK constraints.
     await dataSource.createQueryBuilder().delete().from('event_tags').execute();
+    await invitationsRepository.createQueryBuilder().delete().execute();
     await participantsRepository.createQueryBuilder().delete().execute();
     await tagsRepository.createQueryBuilder().delete().execute();
     await eventsRepository.createQueryBuilder().delete().execute();
@@ -308,5 +312,88 @@ describe('Database tables relations', () => {
 
     expect(eventsCount).toBe(1);
     expect(participantsCount).toBe(0);
+  });
+
+  it('enforces unique invitation pair eventId+invitedUserId', async () => {
+    const organizer = await usersRepository.save(
+      usersRepository.create({
+        email: 'invite-organizer@example.com',
+        password: 'hashed-password',
+        name: 'Invite Organizer',
+      }),
+    );
+
+    const invitedUser = await usersRepository.save(
+      usersRepository.create({
+        email: 'invite-user@example.com',
+        password: 'hashed-password',
+        name: 'Invite User',
+      }),
+    );
+
+    const event = await eventsRepository.save(
+      eventsRepository.create({
+        title: 'Invitation uniqueness event',
+        eventDate: new Date('2026-08-12T12:00:00.000Z'),
+        organizerId: organizer.id,
+      }),
+    );
+
+    await invitationsRepository.save(
+      invitationsRepository.create({
+        eventId: event.id,
+        invitedByUserId: organizer.id,
+        invitedUserId: invitedUser.id,
+      }),
+    );
+
+    await expect(
+      invitationsRepository.save(
+        invitationsRepository.create({
+          eventId: event.id,
+          invitedByUserId: organizer.id,
+          invitedUserId: invitedUser.id,
+        }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('cascades event deletion to invitations', async () => {
+    const organizer = await usersRepository.save(
+      usersRepository.create({
+        email: 'event-delete-organizer@example.com',
+        password: 'hashed-password',
+        name: 'Event Delete Organizer',
+      }),
+    );
+
+    const invitedUser = await usersRepository.save(
+      usersRepository.create({
+        email: 'event-delete-invitee@example.com',
+        password: 'hashed-password',
+        name: 'Event Delete Invitee',
+      }),
+    );
+
+    const event = await eventsRepository.save(
+      eventsRepository.create({
+        title: 'Event invitation cascade test',
+        eventDate: new Date('2026-09-01T12:00:00.000Z'),
+        organizerId: organizer.id,
+      }),
+    );
+
+    await invitationsRepository.save(
+      invitationsRepository.create({
+        eventId: event.id,
+        invitedByUserId: organizer.id,
+        invitedUserId: invitedUser.id,
+      }),
+    );
+
+    await eventsRepository.delete({ id: event.id });
+
+    const invitationsCount = await invitationsRepository.count();
+    expect(invitationsCount).toBe(0);
   });
 });

--- a/backend/src/events/entities/event.entity.ts
+++ b/backend/src/events/entities/event.entity.ts
@@ -12,6 +12,7 @@ import {
 import { User } from '../../users/entities/user.entity';
 import { Participant } from '../../participants/entities/participant.entity';
 import { Tag } from '../../tags/entities/tag.entity';
+import { EventInvitation } from '../../invitations/entities/event-invitation.entity';
 
 export enum EventVisibility {
   PUBLIC = 'public',
@@ -59,6 +60,12 @@ export class Event {
     (participant: Participant): Event => participant.event,
   )
   participants!: Participant[];
+
+  @OneToMany(
+    () => EventInvitation,
+    (invitation: EventInvitation): Event => invitation.event,
+  )
+  invitations!: EventInvitation[];
 
   @ManyToMany(() => Tag, (tag: Tag): Event[] => tag.events)
   @JoinTable({

--- a/backend/src/events/events.service.helpers.ts
+++ b/backend/src/events/events.service.helpers.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException } from '@nestjs/common';
 import { Participant } from '../participants/entities/participant.entity';
 import { Event, EventVisibility } from './entities/event.entity';
+import { EventInvitationStatus } from '../invitations/entities/event-invitation.entity';
 
 export type AuthenticatedUser = {
   sub: string;
@@ -48,8 +49,13 @@ export function assertPrivateEventAccess(
   const isParticipant = event.participants.some(
     (participant) => participant.userId === user.sub,
   );
+  const hasAcceptedInvitation = (event.invitations ?? []).some(
+    (invitation) =>
+      invitation.invitedUserId === user.sub &&
+      invitation.status === EventInvitationStatus.ACCEPTED,
+  );
 
-  if (!isOrganizer && !isParticipant) {
+  if (!isOrganizer && !isParticipant && !hasAcceptedInvitation) {
     throw new ForbiddenException(
       'You do not have access to this private event',
     );

--- a/backend/src/events/events.service.helpers.ts
+++ b/backend/src/events/events.service.helpers.ts
@@ -62,7 +62,7 @@ export function assertPrivateEventAccess(
   }
 }
 
-export function sanitizeParticipantEmails(event: Event): Event {
+export function sanitizeEventForAuthenticatedView(event: Event): Event {
   // Remove participant email from API responses while preserving other user fields.
   const sanitizedParticipants = (event.participants ?? []).map(
     (participant) => {

--- a/backend/src/events/events.service.helpers.ts
+++ b/backend/src/events/events.service.helpers.ts
@@ -79,8 +79,10 @@ export function sanitizeParticipantEmails(event: Event): Event {
     },
   );
 
+  const { invitations: _invitations, ...eventWithoutInvitations } = event;
+
   return {
-    ...event,
+    ...eventWithoutInvitations,
     participants: sanitizedParticipants as Participant[],
-  };
+  } as Event;
 }

--- a/backend/src/events/events.service.spec.ts
+++ b/backend/src/events/events.service.spec.ts
@@ -646,6 +646,7 @@ describe('EventsService', () => {
     );
 
     expect(result.participants?.[0]?.user).not.toHaveProperty('email');
+    expect(result).not.toHaveProperty('invitations');
   });
 
   it('findOne throws when unauthenticated user requests private event', async () => {

--- a/backend/src/events/events.service.spec.ts
+++ b/backend/src/events/events.service.spec.ts
@@ -630,7 +630,12 @@ describe('EventsService', () => {
     expect(eventsRepository.findOne).toHaveBeenCalledTimes(1);
     expect(eventsRepository.findOne).toHaveBeenCalledWith({
       where: { id: 'event-id' },
-      relations: { organizer: true, participants: { user: true }, tags: true },
+      relations: {
+        organizer: true,
+        participants: { user: true },
+        invitations: true,
+        tags: true,
+      },
     });
 
     expect(result.participants?.[0]?.user).toEqual(
@@ -707,7 +712,12 @@ describe('EventsService', () => {
     expect(eventsRepository.findOne).toHaveBeenCalledTimes(1);
     expect(eventsRepository.findOne).toHaveBeenCalledWith({
       where: { id: 'event-id' },
-      relations: { organizer: true, participants: { user: true }, tags: true },
+      relations: {
+        organizer: true,
+        participants: { user: true },
+        invitations: true,
+        tags: true,
+      },
     });
 
     expect(result.participants?.[0]?.user).not.toHaveProperty('email');
@@ -719,6 +729,7 @@ describe('EventsService', () => {
       visibility: 'private',
       organizerId: 'organizer-id',
       participants: [{ userId: 'participant-id' }],
+      invitations: [],
     });
 
     await expect(
@@ -727,6 +738,32 @@ describe('EventsService', () => {
         email: 'another@example.com',
       }),
     ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('findOne returns private event to user with accepted invitation', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      visibility: 'private',
+      organizerId: 'organizer-id',
+      participants: [],
+      invitations: [
+        {
+          invitedUserId: 'invited-user-id',
+          status: 'accepted',
+        },
+      ],
+    });
+
+    const result = await service.findOne('event-id', {
+      sub: 'invited-user-id',
+      email: 'invited@example.com',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'event-id',
+      }),
+    );
   });
 
   it('joinEvent throws when capacity is reached', async () => {

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -75,7 +75,12 @@ export class EventsService {
 
   async findOne(id: string, user?: AuthenticatedUser): Promise<Event> {
     const relations = user
-      ? { organizer: true, participants: { user: true }, tags: true }
+      ? {
+          organizer: true,
+          participants: { user: true },
+          invitations: true,
+          tags: true,
+        }
       : { organizer: true, participants: true, tags: true };
 
     const event = await this.eventsRepository.findOne({

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -14,7 +14,7 @@ import {
   assertPrivateEventAccess,
   AuthenticatedUser,
   mergeAndSortCalendarEvents,
-  sanitizeParticipantEmails,
+  sanitizeEventForAuthenticatedView,
 } from './events.service.helpers';
 import {
   assertCapacityAvailable,
@@ -94,7 +94,7 @@ export class EventsService {
 
     assertPrivateEventAccess(event, user);
 
-    return user ? sanitizeParticipantEmails(event) : event;
+    return user ? sanitizeEventForAuthenticatedView(event) : event;
   }
 
   async create(

--- a/backend/src/invitations/dto/create-invitation.dto.ts
+++ b/backend/src/invitations/dto/create-invitation.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class CreateInvitationDto {
+  @ApiProperty({
+    example: '4f3f8c2f-22d5-4f9f-a5ec-9f47d8f83514',
+    description: 'User ID that should receive invitation to the private event',
+  })
+  @IsUUID()
+  invitedUserId!: string;
+}

--- a/backend/src/invitations/entities/event-invitation.entity.ts
+++ b/backend/src/invitations/entities/event-invitation.entity.ts
@@ -1,0 +1,65 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
+import { User } from '../../users/entities/user.entity';
+
+export enum EventInvitationStatus {
+  PENDING = 'pending',
+  ACCEPTED = 'accepted',
+  DECLINED = 'declined',
+  REVOKED = 'revoked',
+}
+
+@Entity('event_invitations')
+@Unique(['eventId', 'invitedUserId'])
+export class EventInvitation {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Event, (event) => event.invitations, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'eventId' })
+  event!: Event;
+
+  @Column({ type: 'uuid' })
+  eventId!: string;
+
+  @ManyToOne(() => User, (user) => user.sentInvitations, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'invitedByUserId' })
+  invitedByUser!: User;
+
+  @Column({ type: 'uuid' })
+  invitedByUserId!: string;
+
+  @ManyToOne(() => User, (user) => user.receivedInvitations, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'invitedUserId' })
+  invitedUser!: User;
+
+  @Column({ type: 'uuid' })
+  invitedUserId!: string;
+
+  @Column({
+    type: 'enum',
+    enum: EventInvitationStatus,
+    default: EventInvitationStatus.PENDING,
+  })
+  status!: EventInvitationStatus;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/invitations/entities/event-invitation.entity.ts
+++ b/backend/src/invitations/entities/event-invitation.entity.ts
@@ -14,7 +14,6 @@ export enum EventInvitationStatus {
   PENDING = 'pending',
   ACCEPTED = 'accepted',
   DECLINED = 'declined',
-  REVOKED = 'revoked',
 }
 
 @Entity('event_invitations')

--- a/backend/src/invitations/invitations-lifecycle.controller.spec.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvitationsLifecycleController } from './invitations-lifecycle.controller';
+import { InvitationsService } from './invitations.service';
+
+describe('InvitationsLifecycleController', () => {
+  let controller: InvitationsLifecycleController;
+  let invitationsService: {
+    listMyInvitations: jest.Mock;
+    acceptInvitation: jest.Mock;
+    declineInvitation: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    invitationsService = {
+      listMyInvitations: jest.fn(),
+      acceptInvitation: jest.fn(),
+      declineInvitation: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvitationsLifecycleController],
+      providers: [
+        {
+          provide: InvitationsService,
+          useValue: invitationsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InvitationsLifecycleController>(
+      InvitationsLifecycleController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('listMyInvitations delegates to service with current user', async () => {
+    const user = { sub: 'invitee-id', email: 'invitee@example.com' };
+    const invitations = [{ id: 'invitation-id' }];
+
+    invitationsService.listMyInvitations.mockResolvedValue(invitations);
+
+    const result = await controller.listMyInvitations(user);
+
+    expect(invitationsService.listMyInvitations).toHaveBeenCalledWith(user);
+    expect(result).toEqual(invitations);
+  });
+
+  it('acceptInvitation delegates to service with invitation id and current user', async () => {
+    const user = { sub: 'invitee-id', email: 'invitee@example.com' };
+
+    invitationsService.acceptInvitation.mockResolvedValue({
+      id: 'invitation-id',
+      status: 'accepted',
+    });
+
+    const result = await controller.acceptInvitation('invitation-id', user);
+
+    expect(invitationsService.acceptInvitation).toHaveBeenCalledWith(
+      'invitation-id',
+      user,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'invitation-id',
+        status: 'accepted',
+      }),
+    );
+  });
+
+  it('declineInvitation delegates to service with invitation id and current user', async () => {
+    const user = { sub: 'invitee-id', email: 'invitee@example.com' };
+
+    invitationsService.declineInvitation.mockResolvedValue({
+      id: 'invitation-id',
+      status: 'declined',
+    });
+
+    const result = await controller.declineInvitation('invitation-id', user);
+
+    expect(invitationsService.declineInvitation).toHaveBeenCalledWith(
+      'invitation-id',
+      user,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'invitation-id',
+        status: 'declined',
+      }),
+    );
+  });
+});

--- a/backend/src/invitations/invitations-lifecycle.controller.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.ts
@@ -46,8 +46,9 @@ export class InvitationsLifecycleController {
   }
 
   @Post(':invitationId/decline')
+  @HttpCode(200)
   @ApiOperation({ summary: 'Decline invitation for current user' })
-  @ApiResponse({ status: 201, description: 'Invitation declined' })
+  @ApiResponse({ status: 200, description: 'Invitation declined' })
   declineInvitation(
     @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
     @CurrentUser() user: { sub: string; email: string },

--- a/backend/src/invitations/invitations-lifecycle.controller.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  HttpCode,
   Param,
   ParseUUIDPipe,
   Post,
@@ -34,8 +35,9 @@ export class InvitationsLifecycleController {
   }
 
   @Post(':invitationId/accept')
+  @HttpCode(200)
   @ApiOperation({ summary: 'Accept invitation for current user' })
-  @ApiResponse({ status: 201, description: 'Invitation accepted' })
+  @ApiResponse({ status: 200, description: 'Invitation accepted' })
   acceptInvitation(
     @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
     @CurrentUser() user: { sub: string; email: string },

--- a/backend/src/invitations/invitations-lifecycle.controller.ts
+++ b/backend/src/invitations/invitations-lifecycle.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsService } from './invitations.service';
+
+@ApiTags('invitations')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('invitations')
+export class InvitationsLifecycleController {
+  constructor(private readonly invitationsService: InvitationsService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'List invitations for current user' })
+  @ApiResponse({ status: 200, description: 'Current user invitations list' })
+  listMyInvitations(
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation[]> {
+    return this.invitationsService.listMyInvitations(user);
+  }
+
+  @Post(':invitationId/accept')
+  @ApiOperation({ summary: 'Accept invitation for current user' })
+  @ApiResponse({ status: 201, description: 'Invitation accepted' })
+  acceptInvitation(
+    @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation> {
+    return this.invitationsService.acceptInvitation(invitationId, user);
+  }
+
+  @Post(':invitationId/decline')
+  @ApiOperation({ summary: 'Decline invitation for current user' })
+  @ApiResponse({ status: 201, description: 'Invitation declined' })
+  declineInvitation(
+    @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation> {
+    return this.invitationsService.declineInvitation(invitationId, user);
+  }
+}

--- a/backend/src/invitations/invitations.controller.spec.ts
+++ b/backend/src/invitations/invitations.controller.spec.ts
@@ -4,14 +4,25 @@ import { InvitationsService } from './invitations.service';
 
 describe('InvitationsController', () => {
   let controller: InvitationsController;
+  let invitationsService: {
+    createInvitation: jest.Mock;
+    listInvitationsForEvent: jest.Mock;
+    revokeInvitation: jest.Mock;
+  };
 
   beforeEach(async () => {
+    invitationsService = {
+      createInvitation: jest.fn(),
+      listInvitationsForEvent: jest.fn(),
+      revokeInvitation: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [InvitationsController],
       providers: [
         {
           provide: InvitationsService,
-          useValue: {},
+          useValue: invitationsService,
         },
       ],
     }).compile();
@@ -21,5 +32,62 @@ describe('InvitationsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('createInvitation delegates to service with eventId, dto and current user', async () => {
+    const user = { sub: 'organizer-id', email: 'organizer@example.com' };
+    const dto = { invitedUserId: 'invitee-id' };
+    const createdInvitation = {
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedByUserId: user.sub,
+      invitedUserId: dto.invitedUserId,
+    };
+
+    invitationsService.createInvitation.mockResolvedValue(createdInvitation);
+
+    const result = await controller.createInvitation('event-id', dto, user);
+
+    expect(invitationsService.createInvitation).toHaveBeenCalledWith(
+      'event-id',
+      dto,
+      user,
+    );
+    expect(result).toEqual(createdInvitation);
+  });
+
+  it('listInvitations delegates to service with eventId and current user', async () => {
+    const user = { sub: 'organizer-id', email: 'organizer@example.com' };
+    const invitations = [
+      {
+        id: 'invitation-id',
+        eventId: 'event-id',
+        invitedByUserId: user.sub,
+        invitedUserId: 'invitee-id',
+      },
+    ];
+
+    invitationsService.listInvitationsForEvent.mockResolvedValue(invitations);
+
+    const result = await controller.listInvitations('event-id', user);
+
+    expect(invitationsService.listInvitationsForEvent).toHaveBeenCalledWith(
+      'event-id',
+      user,
+    );
+    expect(result).toEqual(invitations);
+  });
+
+  it('revokeInvitation delegates to service with eventId, invitationId and current user', async () => {
+    const user = { sub: 'organizer-id', email: 'organizer@example.com' };
+    invitationsService.revokeInvitation.mockResolvedValue(undefined);
+
+    await controller.revokeInvitation('event-id', 'invitation-id', user);
+
+    expect(invitationsService.revokeInvitation).toHaveBeenCalledWith(
+      'event-id',
+      'invitation-id',
+      user,
+    );
   });
 });

--- a/backend/src/invitations/invitations.controller.spec.ts
+++ b/backend/src/invitations/invitations.controller.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvitationsController } from './invitations.controller';
+import { InvitationsService } from './invitations.service';
+
+describe('InvitationsController', () => {
+  let controller: InvitationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvitationsController],
+      providers: [
+        {
+          provide: InvitationsService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InvitationsController>(InvitationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/invitations/invitations.controller.ts
+++ b/backend/src/invitations/invitations.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { CreateInvitationDto } from './dto/create-invitation.dto';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsService } from './invitations.service';
+
+@ApiTags('event invitations')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('events/:eventId/invitations')
+export class InvitationsController {
+  constructor(private readonly invitationsService: InvitationsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Invite user to private event (organizer only)' })
+  @ApiResponse({ status: 201, description: 'Invitation created successfully' })
+  createInvitation(
+    @Param('eventId') eventId: string,
+    @Body() dto: CreateInvitationDto,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation> {
+    return this.invitationsService.createInvitation(eventId, dto, user);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List private event invitations (organizer only)' })
+  @ApiResponse({ status: 200, description: 'Invitations list' })
+  listInvitations(
+    @Param('eventId') eventId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<EventInvitation[]> {
+    return this.invitationsService.listInvitationsForEvent(eventId, user);
+  }
+
+  @Delete(':invitationId')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Revoke invitation (organizer only)' })
+  @ApiResponse({ status: 204, description: 'Invitation revoked successfully' })
+  async revokeInvitation(
+    @Param('eventId') eventId: string,
+    @Param('invitationId') invitationId: string,
+    @CurrentUser() user: { sub: string; email: string },
+  ): Promise<void> {
+    await this.invitationsService.revokeInvitation(eventId, invitationId, user);
+  }
+}

--- a/backend/src/invitations/invitations.controller.ts
+++ b/backend/src/invitations/invitations.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpCode,
   Param,
+  ParseUUIDPipe,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -31,7 +32,7 @@ export class InvitationsController {
   @ApiOperation({ summary: 'Invite user to private event (organizer only)' })
   @ApiResponse({ status: 201, description: 'Invitation created successfully' })
   createInvitation(
-    @Param('eventId') eventId: string,
+    @Param('eventId', new ParseUUIDPipe()) eventId: string,
     @Body() dto: CreateInvitationDto,
     @CurrentUser() user: { sub: string; email: string },
   ): Promise<EventInvitation> {
@@ -42,7 +43,7 @@ export class InvitationsController {
   @ApiOperation({ summary: 'List private event invitations (organizer only)' })
   @ApiResponse({ status: 200, description: 'Invitations list' })
   listInvitations(
-    @Param('eventId') eventId: string,
+    @Param('eventId', new ParseUUIDPipe()) eventId: string,
     @CurrentUser() user: { sub: string; email: string },
   ): Promise<EventInvitation[]> {
     return this.invitationsService.listInvitationsForEvent(eventId, user);
@@ -53,8 +54,8 @@ export class InvitationsController {
   @ApiOperation({ summary: 'Revoke invitation (organizer only)' })
   @ApiResponse({ status: 204, description: 'Invitation revoked successfully' })
   async revokeInvitation(
-    @Param('eventId') eventId: string,
-    @Param('invitationId') invitationId: string,
+    @Param('eventId', new ParseUUIDPipe()) eventId: string,
+    @Param('invitationId', new ParseUUIDPipe()) invitationId: string,
     @CurrentUser() user: { sub: string; email: string },
   ): Promise<void> {
     await this.invitationsService.revokeInvitation(eventId, invitationId, user);

--- a/backend/src/invitations/invitations.module.ts
+++ b/backend/src/invitations/invitations.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Event } from '../events/entities/event.entity';
+import { Participant } from '../participants/entities/participant.entity';
+import { User } from '../users/entities/user.entity';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsController } from './invitations.controller';
+import { InvitationsService } from './invitations.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([EventInvitation, Event, Participant, User]),
+  ],
+  controllers: [InvitationsController],
+  providers: [InvitationsService],
+  exports: [InvitationsService],
+})
+export class InvitationsModule {}

--- a/backend/src/invitations/invitations.module.ts
+++ b/backend/src/invitations/invitations.module.ts
@@ -4,6 +4,7 @@ import { Event } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
 import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsLifecycleController } from './invitations-lifecycle.controller';
 import { InvitationsController } from './invitations.controller';
 import { InvitationsService } from './invitations.service';
 
@@ -11,7 +12,7 @@ import { InvitationsService } from './invitations.service';
   imports: [
     TypeOrmModule.forFeature([EventInvitation, Event, Participant, User]),
   ],
-  controllers: [InvitationsController],
+  controllers: [InvitationsController, InvitationsLifecycleController],
   providers: [InvitationsService],
   exports: [InvitationsService],
 })

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -441,6 +441,64 @@ describe('InvitationsService', () => {
     expect(result).toEqual(invitations);
   });
 
+  it('listMyInvitations hides private event details for non-accepted invitations', async () => {
+    const invitations = [
+      {
+        id: 'pending-invitation-id',
+        invitedUserId: 'invitee-id',
+        status: EventInvitationStatus.PENDING,
+        event: {
+          id: 'private-event-id',
+          title: 'Private party',
+          description: 'Sensitive details',
+          location: 'Secret location',
+          capacity: 10,
+          visibility: EventVisibility.PRIVATE,
+        },
+      },
+      {
+        id: 'accepted-invitation-id',
+        invitedUserId: 'invitee-id',
+        status: EventInvitationStatus.ACCEPTED,
+        event: {
+          id: 'private-event-id-2',
+          title: 'Private party accepted',
+          description: 'Visible details',
+          location: 'Visible location',
+          capacity: 20,
+          visibility: EventVisibility.PRIVATE,
+        },
+      },
+    ];
+
+    invitationsRepository.find.mockResolvedValue(invitations);
+
+    const result = await service.listMyInvitations({
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(result[0].event).toEqual(
+      expect.objectContaining({
+        id: 'private-event-id',
+        title: 'Private party',
+        visibility: EventVisibility.PRIVATE,
+      }),
+    );
+    expect(result[0].event?.description).toBeUndefined();
+    expect(result[0].event?.location).toBeUndefined();
+    expect(result[0].event?.capacity).toBeUndefined();
+
+    expect(result[1].event).toEqual(
+      expect.objectContaining({
+        id: 'private-event-id-2',
+        description: 'Visible details',
+        location: 'Visible location',
+        capacity: 20,
+      }),
+    );
+  });
+
   it('acceptInvitation updates status and creates participant for pending invitation', async () => {
     const invitation = {
       id: 'invitation-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -26,6 +26,7 @@ describe('InvitationsService', () => {
     create: jest.fn(),
     find: jest.fn(),
     findOne: jest.fn(),
+    update: jest.fn(),
     save: jest.fn(),
     delete: jest.fn(),
     manager: {
@@ -449,6 +450,13 @@ describe('InvitationsService', () => {
     };
 
     invitationsRepository.findOne.mockResolvedValue(invitation);
+    invitationsRepository.update.mockResolvedValue({ affected: 1 });
+    invitationsRepository.findOne
+      .mockResolvedValueOnce(invitation)
+      .mockResolvedValueOnce({
+        ...invitation,
+        status: EventInvitationStatus.ACCEPTED,
+      });
     invitationsRepository.save.mockResolvedValue({
       ...invitation,
       status: EventInvitationStatus.ACCEPTED,
@@ -494,6 +502,8 @@ describe('InvitationsService', () => {
       status: EventInvitationStatus.DECLINED,
     });
 
+    invitationsRepository.update.mockResolvedValue({ affected: 0 });
+
     await expect(
       service.acceptInvitation('invitation-id', {
         sub: 'invitee-id',
@@ -512,11 +522,13 @@ describe('InvitationsService', () => {
       status: EventInvitationStatus.PENDING,
     };
 
-    invitationsRepository.findOne.mockResolvedValue(invitation);
-    invitationsRepository.save.mockResolvedValue({
-      ...invitation,
-      status: EventInvitationStatus.DECLINED,
-    });
+    invitationsRepository.update.mockResolvedValue({ affected: 1 });
+    invitationsRepository.findOne
+      .mockResolvedValueOnce(invitation)
+      .mockResolvedValueOnce({
+        ...invitation,
+        status: EventInvitationStatus.DECLINED,
+      });
 
     const result = await service.declineInvitation('invitation-id', {
       sub: 'invitee-id',
@@ -528,5 +540,22 @@ describe('InvitationsService', () => {
         status: EventInvitationStatus.DECLINED,
       }),
     );
+  });
+
+  it('declineInvitation rejects non-pending invitation', async () => {
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.ACCEPTED,
+    });
+    invitationsRepository.update.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      service.declineInvitation('invitation-id', {
+        sub: 'invitee-id',
+        email: 'invitee@example.com',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -333,6 +333,40 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
+  it('revokes invitation for organizer/private event', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'invitation-id',
+      eventId: 'event-id',
+    });
+
+    invitationsRepository.delete.mockResolvedValue({ affected: 1 });
+
+    await expect(
+      service.revokeInvitation('event-id', 'invitation-id', {
+        sub: 'organizer-id',
+        email: 'organizer@example.com',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(invitationsRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        id: 'invitation-id',
+        eventId: 'event-id',
+      },
+    });
+
+    expect(invitationsRepository.delete).toHaveBeenCalledWith({
+      id: 'invitation-id',
+      eventId: 'event-id',
+    });
+  });
+
   it('throws when invitation to revoke is missing', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -1,10 +1,12 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { QueryFailedError } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
@@ -123,6 +125,22 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
+  it('rejects creating invitation for non-organizer with 403', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'owner-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'another-user-id', email: 'user@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('rejects duplicate invitation pair', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',
@@ -137,6 +155,39 @@ describe('InvitationsService', () => {
       eventId: 'event-id',
       invitedUserId: 'invitee-id',
     });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('maps unique violation on save to conflict for concurrent race', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({ id: 'invitee-id' });
+    participantsRepository.findOne.mockResolvedValue(null);
+    invitationsRepository.findOne.mockResolvedValue(null);
+
+    const invitationPayload = {
+      eventId: 'event-id',
+      invitedByUserId: 'organizer-id',
+      invitedUserId: 'invitee-id',
+    };
+
+    invitationsRepository.create.mockReturnValue(invitationPayload);
+    invitationsRepository.save.mockRejectedValue(
+      new QueryFailedError('insert into event_invitations', [], {
+        code: '23505',
+      }),
+    );
 
     await expect(
       service.createInvitation(

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -540,6 +540,10 @@ describe('InvitationsService', () => {
         id: 'invitation-id',
         invitedUserId: 'invitee-id',
       },
+      relations: {
+        event: { organizer: true, tags: true },
+        invitedByUser: true,
+      },
     });
     expect(participantsRepository.create).toHaveBeenCalledWith({
       eventId: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -474,9 +474,6 @@ describe('InvitationsService', () => {
         id: 'invitation-id',
         invitedUserId: 'invitee-id',
       },
-      relations: {
-        event: true,
-      },
     });
     expect(participantsRepository.create).toHaveBeenCalledWith({
       eventId: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -18,6 +18,9 @@ import { InvitationsService } from './invitations.service';
 
 describe('InvitationsService', () => {
   let service: InvitationsService;
+  let transactionManager: {
+    getRepository: jest.Mock;
+  };
 
   const invitationsRepository = {
     create: jest.fn(),
@@ -25,6 +28,9 @@ describe('InvitationsService', () => {
     findOne: jest.fn(),
     save: jest.fn(),
     delete: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
 
   const eventsRepository = {
@@ -43,6 +49,28 @@ describe('InvitationsService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+
+    transactionManager = {
+      getRepository: jest.fn((entity: unknown) => {
+        if (entity === EventInvitation) {
+          return invitationsRepository;
+        }
+
+        if (entity === Participant) {
+          return participantsRepository;
+        }
+
+        return undefined;
+      }),
+    };
+
+    invitationsRepository.manager.transaction.mockImplementation(
+      (
+        callback: (
+          manager: typeof transactionManager,
+        ) => Promise<unknown> | unknown,
+      ) => Promise.resolve(callback(transactionManager)),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -1,0 +1,166 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Event, EventVisibility } from '../events/entities/event.entity';
+import { Participant } from '../participants/entities/participant.entity';
+import { User } from '../users/entities/user.entity';
+import { EventInvitation } from './entities/event-invitation.entity';
+import { InvitationsService } from './invitations.service';
+
+describe('InvitationsService', () => {
+  let service: InvitationsService;
+
+  const invitationsRepository = {
+    create: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const eventsRepository = {
+    findOne: jest.fn(),
+  };
+
+  const participantsRepository = {
+    findOne: jest.fn(),
+  };
+
+  const usersRepository = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvitationsService,
+        {
+          provide: getRepositoryToken(EventInvitation),
+          useValue: invitationsRepository,
+        },
+        {
+          provide: getRepositoryToken(Event),
+          useValue: eventsRepository,
+        },
+        {
+          provide: getRepositoryToken(Participant),
+          useValue: participantsRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<InvitationsService>(InvitationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('creates invitation for private event organizer', async () => {
+    const organizer = { sub: 'organizer-id', email: 'organizer@example.com' };
+
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: organizer.sub,
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({
+      id: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    participantsRepository.findOne.mockResolvedValue(null);
+    invitationsRepository.findOne.mockResolvedValue(null);
+
+    const invitationPayload = {
+      eventId: 'event-id',
+      invitedByUserId: organizer.sub,
+      invitedUserId: 'invitee-id',
+    };
+
+    invitationsRepository.create.mockReturnValue(invitationPayload);
+    invitationsRepository.save.mockResolvedValue({
+      id: 'invitation-id',
+      ...invitationPayload,
+    });
+
+    const result = await service.createInvitation(
+      'event-id',
+      { invitedUserId: 'invitee-id' },
+      organizer,
+    );
+
+    expect(invitationsRepository.create).toHaveBeenCalledWith(
+      invitationPayload,
+    );
+    expect(result.id).toBe('invitation-id');
+  });
+
+  it('rejects creating invitation for public events', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PUBLIC,
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects duplicate invitation pair', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({ id: 'invitee-id' });
+    participantsRepository.findOne.mockResolvedValue(null);
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'existing-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('throws when invitation to revoke is missing', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    invitationsRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.revokeInvitation('event-id', 'missing-invitation-id', {
+        sub: 'organizer-id',
+        email: 'organizer@example.com',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -198,6 +198,76 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(ConflictException);
   });
 
+  it('lists invitations for private event organizer with expected ordering and relations', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    const invitations = [
+      {
+        id: 'invitation-2',
+        eventId: 'event-id',
+        invitedByUserId: 'organizer-id',
+        invitedUserId: 'invitee-2',
+      },
+      {
+        id: 'invitation-1',
+        eventId: 'event-id',
+        invitedByUserId: 'organizer-id',
+        invitedUserId: 'invitee-1',
+      },
+    ];
+
+    invitationsRepository.find.mockResolvedValue(invitations);
+
+    const result = await service.listInvitationsForEvent('event-id', {
+      sub: 'organizer-id',
+      email: 'organizer@example.com',
+    });
+
+    expect(invitationsRepository.find).toHaveBeenCalledWith({
+      where: { eventId: 'event-id' },
+      order: { createdAt: 'DESC' },
+      relations: {
+        invitedByUser: true,
+        invitedUser: true,
+      },
+    });
+    expect(result).toEqual(invitations);
+  });
+
+  it('rejects listing invitations for non-organizer with 403', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'owner-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    await expect(
+      service.listInvitationsForEvent('event-id', {
+        sub: 'another-user-id',
+        email: 'user@example.com',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects listing invitations for public event with 400', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PUBLIC,
+    });
+
+    await expect(
+      service.listInvitationsForEvent('event-id', {
+        sub: 'organizer-id',
+        email: 'organizer@example.com',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
   it('throws when invitation to revoke is missing', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -141,6 +141,71 @@ describe('InvitationsService', () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
+  it('rejects self-invite with 400', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'organizer-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(usersRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when invited user does not exist', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'missing-user-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('returns 409 when invited user is already a participant', async () => {
+    eventsRepository.findOne.mockResolvedValue({
+      id: 'event-id',
+      organizerId: 'organizer-id',
+      visibility: EventVisibility.PRIVATE,
+    });
+
+    usersRepository.findOne.mockResolvedValue({
+      id: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    participantsRepository.findOne.mockResolvedValue({
+      id: 'participant-id',
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+
+    await expect(
+      service.createInvitation(
+        'event-id',
+        { invitedUserId: 'invitee-id' },
+        { sub: 'organizer-id', email: 'organizer@example.com' },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(invitationsRepository.findOne).not.toHaveBeenCalled();
+  });
+
   it('rejects duplicate invitation pair', async () => {
     eventsRepository.findOne.mockResolvedValue({
       id: 'event-id',

--- a/backend/src/invitations/invitations.service.spec.ts
+++ b/backend/src/invitations/invitations.service.spec.ts
@@ -10,7 +10,10 @@ import { QueryFailedError } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
-import { EventInvitation } from './entities/event-invitation.entity';
+import {
+  EventInvitation,
+  EventInvitationStatus,
+} from './entities/event-invitation.entity';
 import { InvitationsService } from './invitations.service';
 
 describe('InvitationsService', () => {
@@ -30,6 +33,8 @@ describe('InvitationsService', () => {
 
   const participantsRepository = {
     findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
   };
 
   const usersRepository = {
@@ -247,11 +252,14 @@ describe('InvitationsService', () => {
       invitedUserId: 'invitee-id',
     };
 
+    const driverError = new Error('duplicate invitation') as Error & {
+      code: string;
+    };
+    driverError.code = '23505';
+
     invitationsRepository.create.mockReturnValue(invitationPayload);
     invitationsRepository.save.mockRejectedValue(
-      new QueryFailedError('insert into event_invitations', [], {
-        code: '23505',
-      }),
+      new QueryFailedError('insert into event_invitations', [], driverError),
     );
 
     await expect(
@@ -382,5 +390,118 @@ describe('InvitationsService', () => {
         email: 'organizer@example.com',
       }),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('listMyInvitations returns current user invitations with relations and ordering', async () => {
+    const invitations = [{ id: 'invitation-id', invitedUserId: 'invitee-id' }];
+    invitationsRepository.find.mockResolvedValue(invitations);
+
+    const result = await service.listMyInvitations({
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(invitationsRepository.find).toHaveBeenCalledWith({
+      where: { invitedUserId: 'invitee-id' },
+      order: { createdAt: 'DESC' },
+      relations: {
+        event: { organizer: true, tags: true },
+        invitedByUser: true,
+      },
+    });
+    expect(result).toEqual(invitations);
+  });
+
+  it('acceptInvitation updates status and creates participant for pending invitation', async () => {
+    const invitation = {
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.PENDING,
+    };
+
+    invitationsRepository.findOne.mockResolvedValue(invitation);
+    invitationsRepository.save.mockResolvedValue({
+      ...invitation,
+      status: EventInvitationStatus.ACCEPTED,
+    });
+    participantsRepository.findOne.mockResolvedValue(null);
+    participantsRepository.create.mockReturnValue({
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+    participantsRepository.save.mockResolvedValue({
+      id: 'participant-id',
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+
+    const result = await service.acceptInvitation('invitation-id', {
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(invitationsRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        id: 'invitation-id',
+        invitedUserId: 'invitee-id',
+      },
+      relations: {
+        event: true,
+      },
+    });
+    expect(participantsRepository.create).toHaveBeenCalledWith({
+      eventId: 'event-id',
+      userId: 'invitee-id',
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: EventInvitationStatus.ACCEPTED,
+      }),
+    );
+  });
+
+  it('acceptInvitation rejects non-pending invitation', async () => {
+    invitationsRepository.findOne.mockResolvedValue({
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.DECLINED,
+    });
+
+    await expect(
+      service.acceptInvitation('invitation-id', {
+        sub: 'invitee-id',
+        email: 'invitee@example.com',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(participantsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('declineInvitation updates status for pending invitation', async () => {
+    const invitation = {
+      id: 'invitation-id',
+      eventId: 'event-id',
+      invitedUserId: 'invitee-id',
+      status: EventInvitationStatus.PENDING,
+    };
+
+    invitationsRepository.findOne.mockResolvedValue(invitation);
+    invitationsRepository.save.mockResolvedValue({
+      ...invitation,
+      status: EventInvitationStatus.DECLINED,
+    });
+
+    const result = await service.declineInvitation('invitation-id', {
+      sub: 'invitee-id',
+      email: 'invitee@example.com',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: EventInvitationStatus.DECLINED,
+      }),
+    );
   });
 });

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -12,7 +12,10 @@ import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
 import { AuthenticatedUser } from '../common/types/authenticated-request';
 import { CreateInvitationDto } from './dto/create-invitation.dto';
-import { EventInvitation } from './entities/event-invitation.entity';
+import {
+  EventInvitation,
+  EventInvitationStatus,
+} from './entities/event-invitation.entity';
 
 @Injectable()
 export class InvitationsService {
@@ -124,6 +127,75 @@ export class InvitationsService {
     });
   }
 
+  async listMyInvitations(user: AuthenticatedUser): Promise<EventInvitation[]> {
+    return this.invitationsRepository.find({
+      where: { invitedUserId: user.sub },
+      order: { createdAt: 'DESC' },
+      relations: {
+        event: { organizer: true, tags: true },
+        invitedByUser: true,
+      },
+    });
+  }
+
+  async acceptInvitation(
+    invitationId: string,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation> {
+    const invitation = await this.getInvitationForInvitedUser(
+      invitationId,
+      user.sub,
+    );
+
+    if (invitation.status !== EventInvitationStatus.PENDING) {
+      throw new ConflictException('Invitation is not pending');
+    }
+
+    invitation.status = EventInvitationStatus.ACCEPTED;
+    const savedInvitation = await this.invitationsRepository.save(invitation);
+
+    const existingParticipant = await this.participantsRepository.findOne({
+      where: {
+        eventId: invitation.eventId,
+        userId: user.sub,
+      },
+    });
+
+    if (!existingParticipant) {
+      const participant = this.participantsRepository.create({
+        eventId: invitation.eventId,
+        userId: user.sub,
+      });
+
+      try {
+        await this.participantsRepository.save(participant);
+      } catch (error: unknown) {
+        if (!this.isUniqueViolationError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    return savedInvitation;
+  }
+
+  async declineInvitation(
+    invitationId: string,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation> {
+    const invitation = await this.getInvitationForInvitedUser(
+      invitationId,
+      user.sub,
+    );
+
+    if (invitation.status !== EventInvitationStatus.PENDING) {
+      throw new ConflictException('Invitation is not pending');
+    }
+
+    invitation.status = EventInvitationStatus.DECLINED;
+    return this.invitationsRepository.save(invitation);
+  }
+
   private async assertOrganizerCanManageInvitations(
     eventId: string,
     userId: string,
@@ -154,5 +226,26 @@ export class InvitationsService {
 
     const driverError = error.driverError as { code?: string } | undefined;
     return driverError?.code === '23505';
+  }
+
+  private async getInvitationForInvitedUser(
+    invitationId: string,
+    invitedUserId: string,
+  ): Promise<EventInvitation> {
+    const invitation = await this.invitationsRepository.findOne({
+      where: {
+        id: invitationId,
+        invitedUserId,
+      },
+      relations: {
+        event: true,
+      },
+    });
+
+    if (!invitation) {
+      throw new NotFoundException('Invitation not found');
+    }
+
+    return invitation;
   }
 }

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -284,13 +284,17 @@ export class InvitationsService {
         id: invitationId,
         invitedUserId,
       },
+      relations: {
+        event: { organizer: true, tags: true },
+        invitedByUser: true,
+      },
     });
 
     if (!invitation) {
       throw new NotFoundException('Invitation not found');
     }
 
-    return invitation;
+    return this.sanitizeInvitationForInviteeView(invitation);
   }
 
   private sanitizeInvitationForInviteeView(

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -128,7 +128,7 @@ export class InvitationsService {
   }
 
   async listMyInvitations(user: AuthenticatedUser): Promise<EventInvitation[]> {
-    return this.invitationsRepository.find({
+    const invitations = await this.invitationsRepository.find({
       where: { invitedUserId: user.sub },
       order: { createdAt: 'DESC' },
       relations: {
@@ -136,6 +136,10 @@ export class InvitationsService {
         invitedByUser: true,
       },
     });
+
+    return invitations.map((invitation) =>
+      this.sanitizeInvitationForInviteeView(invitation),
+    );
   }
 
   async acceptInvitation(
@@ -287,5 +291,35 @@ export class InvitationsService {
     }
 
     return invitation;
+  }
+
+  private sanitizeInvitationForInviteeView(
+    invitation: EventInvitation,
+  ): EventInvitation {
+    const event = invitation.event;
+
+    if (!event) {
+      return invitation;
+    }
+
+    const shouldHidePrivateDetails =
+      event.visibility === EventVisibility.PRIVATE &&
+      invitation.status !== EventInvitationStatus.ACCEPTED;
+
+    if (!shouldHidePrivateDetails) {
+      return invitation;
+    }
+
+    const {
+      description: _description,
+      location: _location,
+      capacity: _capacity,
+      ...eventPreview
+    } = event;
+
+    return {
+      ...invitation,
+      event: eventPreview as Event,
+    };
   }
 }

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -192,19 +192,11 @@ export class InvitationsService {
         }
       }
 
-      const updatedInvitation =
-        await transactionalInvitationsRepository.findOne({
-          where: {
-            id: invitation.id,
-            invitedUserId: user.sub,
-          },
-        });
-
-      if (!updatedInvitation) {
-        throw new NotFoundException('Invitation not found');
-      }
-
-      return updatedInvitation;
+      return this.getInvitationForInvitedUser(
+        invitation.id,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
     });
   }
 
@@ -237,19 +229,11 @@ export class InvitationsService {
         throw new ConflictException('Invitation is not pending');
       }
 
-      const updatedInvitation =
-        await transactionalInvitationsRepository.findOne({
-          where: {
-            id: invitation.id,
-            invitedUserId: user.sub,
-          },
-        });
-
-      if (!updatedInvitation) {
-        throw new NotFoundException('Invitation not found');
-      }
-
-      return updatedInvitation;
+      return this.getInvitationForInvitedUser(
+        invitation.id,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
     });
   }
 

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -142,41 +142,51 @@ export class InvitationsService {
     invitationId: string,
     user: AuthenticatedUser,
   ): Promise<EventInvitation> {
-    const invitation = await this.getInvitationForInvitedUser(
-      invitationId,
-      user.sub,
-    );
+    return this.invitationsRepository.manager.transaction(async (manager) => {
+      const transactionalInvitationsRepository =
+        manager.getRepository(EventInvitation);
+      const transactionalParticipantsRepository =
+        manager.getRepository(Participant);
 
-    if (invitation.status !== EventInvitationStatus.PENDING) {
-      throw new ConflictException('Invitation is not pending');
-    }
+      const invitation = await this.getInvitationForInvitedUser(
+        invitationId,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
 
-    invitation.status = EventInvitationStatus.ACCEPTED;
-    const savedInvitation = await this.invitationsRepository.save(invitation);
+      if (invitation.status !== EventInvitationStatus.PENDING) {
+        throw new ConflictException('Invitation is not pending');
+      }
 
-    const existingParticipant = await this.participantsRepository.findOne({
-      where: {
-        eventId: invitation.eventId,
-        userId: user.sub,
-      },
-    });
+      invitation.status = EventInvitationStatus.ACCEPTED;
+      const savedInvitation =
+        await transactionalInvitationsRepository.save(invitation);
 
-    if (!existingParticipant) {
-      const participant = this.participantsRepository.create({
-        eventId: invitation.eventId,
-        userId: user.sub,
-      });
+      const existingParticipant =
+        await transactionalParticipantsRepository.findOne({
+          where: {
+            eventId: invitation.eventId,
+            userId: user.sub,
+          },
+        });
 
-      try {
-        await this.participantsRepository.save(participant);
-      } catch (error: unknown) {
-        if (!this.isUniqueViolationError(error)) {
-          throw error;
+      if (!existingParticipant) {
+        const participant = transactionalParticipantsRepository.create({
+          eventId: invitation.eventId,
+          userId: user.sub,
+        });
+
+        try {
+          await transactionalParticipantsRepository.save(participant);
+        } catch (error: unknown) {
+          if (!this.isUniqueViolationError(error)) {
+            throw error;
+          }
         }
       }
-    }
 
-    return savedInvitation;
+      return savedInvitation;
+    });
   }
 
   async declineInvitation(
@@ -231,8 +241,10 @@ export class InvitationsService {
   private async getInvitationForInvitedUser(
     invitationId: string,
     invitedUserId: string,
+    invitationsRepository: Repository<EventInvitation> = this
+      .invitationsRepository,
   ): Promise<EventInvitation> {
-    const invitation = await this.invitationsRepository.findOne({
+    const invitation = await invitationsRepository.findOne({
       where: {
         id: invitationId,
         invitedUserId,

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -1,11 +1,12 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
@@ -72,7 +73,15 @@ export class InvitationsService {
       invitedUserId: dto.invitedUserId,
     });
 
-    return this.invitationsRepository.save(invitation);
+    try {
+      return await this.invitationsRepository.save(invitation);
+    } catch (error: unknown) {
+      if (this.isUniqueViolationError(error)) {
+        throw new ConflictException('Invitation already exists for this user');
+      }
+
+      throw error;
+    }
   }
 
   async listInvitationsForEvent(
@@ -128,7 +137,7 @@ export class InvitationsService {
     }
 
     if (event.organizerId !== userId) {
-      throw new BadRequestException('Only organizer can manage invitations');
+      throw new ForbiddenException('Only organizer can manage invitations');
     }
 
     if (event.visibility !== EventVisibility.PRIVATE) {
@@ -136,5 +145,14 @@ export class InvitationsService {
         'Invitations are available only for private events',
       );
     }
+  }
+
+  private isUniqueViolationError(error: unknown): boolean {
+    if (!(error instanceof QueryFailedError)) {
+      return false;
+    }
+
+    const driverError = error.driverError as { code?: string } | undefined;
+    return driverError?.code === '23505';
   }
 }

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -10,7 +10,7 @@ import { QueryFailedError, Repository } from 'typeorm';
 import { Event, EventVisibility } from '../events/entities/event.entity';
 import { Participant } from '../participants/entities/participant.entity';
 import { User } from '../users/entities/user.entity';
-import { AuthenticatedUser } from '../events/events.service.helpers';
+import { AuthenticatedUser } from '../common/types/authenticated-request';
 import { CreateInvitationDto } from './dto/create-invitation.dto';
 import { EventInvitation } from './entities/event-invitation.entity';
 

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -154,13 +154,20 @@ export class InvitationsService {
         transactionalInvitationsRepository,
       );
 
-      if (invitation.status !== EventInvitationStatus.PENDING) {
+      const updateResult = await transactionalInvitationsRepository.update(
+        {
+          id: invitation.id,
+          invitedUserId: user.sub,
+          status: EventInvitationStatus.PENDING,
+        },
+        {
+          status: EventInvitationStatus.ACCEPTED,
+        },
+      );
+
+      if (updateResult.affected !== 1) {
         throw new ConflictException('Invitation is not pending');
       }
-
-      invitation.status = EventInvitationStatus.ACCEPTED;
-      const savedInvitation =
-        await transactionalInvitationsRepository.save(invitation);
 
       const existingParticipant =
         await transactionalParticipantsRepository.findOne({
@@ -185,7 +192,19 @@ export class InvitationsService {
         }
       }
 
-      return savedInvitation;
+      const updatedInvitation =
+        await transactionalInvitationsRepository.findOne({
+          where: {
+            id: invitation.id,
+            invitedUserId: user.sub,
+          },
+        });
+
+      if (!updatedInvitation) {
+        throw new NotFoundException('Invitation not found');
+      }
+
+      return updatedInvitation;
     });
   }
 
@@ -193,17 +212,45 @@ export class InvitationsService {
     invitationId: string,
     user: AuthenticatedUser,
   ): Promise<EventInvitation> {
-    const invitation = await this.getInvitationForInvitedUser(
-      invitationId,
-      user.sub,
-    );
+    return this.invitationsRepository.manager.transaction(async (manager) => {
+      const transactionalInvitationsRepository =
+        manager.getRepository(EventInvitation);
 
-    if (invitation.status !== EventInvitationStatus.PENDING) {
-      throw new ConflictException('Invitation is not pending');
-    }
+      const invitation = await this.getInvitationForInvitedUser(
+        invitationId,
+        user.sub,
+        transactionalInvitationsRepository,
+      );
 
-    invitation.status = EventInvitationStatus.DECLINED;
-    return this.invitationsRepository.save(invitation);
+      const updateResult = await transactionalInvitationsRepository.update(
+        {
+          id: invitation.id,
+          invitedUserId: user.sub,
+          status: EventInvitationStatus.PENDING,
+        },
+        {
+          status: EventInvitationStatus.DECLINED,
+        },
+      );
+
+      if (updateResult.affected !== 1) {
+        throw new ConflictException('Invitation is not pending');
+      }
+
+      const updatedInvitation =
+        await transactionalInvitationsRepository.findOne({
+          where: {
+            id: invitation.id,
+            invitedUserId: user.sub,
+          },
+        });
+
+      if (!updatedInvitation) {
+        throw new NotFoundException('Invitation not found');
+      }
+
+      return updatedInvitation;
+    });
   }
 
   private async assertOrganizerCanManageInvitations(

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -249,9 +249,6 @@ export class InvitationsService {
         id: invitationId,
         invitedUserId,
       },
-      relations: {
-        event: true,
-      },
     });
 
     if (!invitation) {

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -1,0 +1,140 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Event, EventVisibility } from '../events/entities/event.entity';
+import { Participant } from '../participants/entities/participant.entity';
+import { User } from '../users/entities/user.entity';
+import { AuthenticatedUser } from '../events/events.service.helpers';
+import { CreateInvitationDto } from './dto/create-invitation.dto';
+import { EventInvitation } from './entities/event-invitation.entity';
+
+@Injectable()
+export class InvitationsService {
+  constructor(
+    @InjectRepository(EventInvitation)
+    private readonly invitationsRepository: Repository<EventInvitation>,
+    @InjectRepository(Event)
+    private readonly eventsRepository: Repository<Event>,
+    @InjectRepository(Participant)
+    private readonly participantsRepository: Repository<Participant>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async createInvitation(
+    eventId: string,
+    dto: CreateInvitationDto,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation> {
+    await this.assertOrganizerCanManageInvitations(eventId, user.sub);
+
+    if (dto.invitedUserId === user.sub) {
+      throw new BadRequestException('Organizer cannot invite themselves');
+    }
+
+    const invitedUser = await this.usersRepository.findOne({
+      where: { id: dto.invitedUserId },
+    });
+
+    if (!invitedUser) {
+      throw new NotFoundException('Invited user not found');
+    }
+
+    const existingParticipant = await this.participantsRepository.findOne({
+      where: { eventId, userId: dto.invitedUserId },
+    });
+
+    if (existingParticipant) {
+      throw new ConflictException(
+        'User is already a participant of this event',
+      );
+    }
+
+    const existingInvitation = await this.invitationsRepository.findOne({
+      where: {
+        eventId,
+        invitedUserId: dto.invitedUserId,
+      },
+    });
+
+    if (existingInvitation) {
+      throw new ConflictException('Invitation already exists for this user');
+    }
+
+    const invitation = this.invitationsRepository.create({
+      eventId,
+      invitedByUserId: user.sub,
+      invitedUserId: dto.invitedUserId,
+    });
+
+    return this.invitationsRepository.save(invitation);
+  }
+
+  async listInvitationsForEvent(
+    eventId: string,
+    user: AuthenticatedUser,
+  ): Promise<EventInvitation[]> {
+    await this.assertOrganizerCanManageInvitations(eventId, user.sub);
+
+    return this.invitationsRepository.find({
+      where: { eventId },
+      order: { createdAt: 'DESC' },
+      relations: {
+        invitedByUser: true,
+        invitedUser: true,
+      },
+    });
+  }
+
+  async revokeInvitation(
+    eventId: string,
+    invitationId: string,
+    user: AuthenticatedUser,
+  ): Promise<void> {
+    await this.assertOrganizerCanManageInvitations(eventId, user.sub);
+
+    const invitation = await this.invitationsRepository.findOne({
+      where: {
+        id: invitationId,
+        eventId,
+      },
+    });
+
+    if (!invitation) {
+      throw new NotFoundException('Invitation not found');
+    }
+
+    await this.invitationsRepository.delete({
+      id: invitation.id,
+      eventId,
+    });
+  }
+
+  private async assertOrganizerCanManageInvitations(
+    eventId: string,
+    userId: string,
+  ): Promise<void> {
+    const event = await this.eventsRepository.findOne({
+      where: { id: eventId },
+    });
+
+    if (!event) {
+      throw new NotFoundException('Event not found');
+    }
+
+    if (event.organizerId !== userId) {
+      throw new BadRequestException('Only organizer can manage invitations');
+    }
+
+    if (event.visibility !== EventVisibility.PRIVATE) {
+      throw new BadRequestException(
+        'Invitations are available only for private events',
+      );
+    }
+  }
+}

--- a/backend/src/migrations/1760000007000-CreateEventInvitations.ts
+++ b/backend/src/migrations/1760000007000-CreateEventInvitations.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateEventInvitations1760000007000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "CREATE TYPE \"event_invitations_status_enum\" AS ENUM('pending', 'accepted', 'declined', 'revoked')",
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "event_invitations" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "eventId" uuid NOT NULL,
+        "invitedByUserId" uuid NOT NULL,
+        "invitedUserId" uuid NOT NULL,
+        "status" "event_invitations_status_enum" NOT NULL DEFAULT 'pending',
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_event_invitations_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_event_invitations_event_user" UNIQUE ("eventId", "invitedUserId"),
+        CONSTRAINT "FK_event_invitations_event" FOREIGN KEY ("eventId") REFERENCES "events"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_event_invitations_invited_by_user" FOREIGN KEY ("invitedByUserId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_event_invitations_invited_user" FOREIGN KEY ("invitedUserId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+
+    await queryRunner.query(
+      'CREATE INDEX "IDX_event_invitations_event_id" ON "event_invitations" ("eventId")',
+    );
+
+    await queryRunner.query(
+      'CREATE INDEX "IDX_event_invitations_invited_user_id" ON "event_invitations" ("invitedUserId")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_event_invitations_invited_user_id"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_event_invitations_event_id"',
+    );
+    await queryRunner.query('DROP TABLE "event_invitations"');
+    await queryRunner.query('DROP TYPE "event_invitations_status_enum"');
+  }
+}

--- a/backend/src/migrations/1760000007000-CreateEventInvitations.ts
+++ b/backend/src/migrations/1760000007000-CreateEventInvitations.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class CreateEventInvitations1760000007000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      "CREATE TYPE \"event_invitations_status_enum\" AS ENUM('pending', 'accepted', 'declined', 'revoked')",
+      "CREATE TYPE \"event_invitations_status_enum\" AS ENUM('pending', 'accepted', 'declined')",
     );
 
     await queryRunner.query(`

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm';
 import { Event } from '../../events/entities/event.entity';
 import { Participant } from '../../participants/entities/participant.entity';
+import { EventInvitation } from '../../invitations/entities/event-invitation.entity';
 
 @Entity('users')
 export class User {
@@ -30,4 +31,10 @@ export class User {
 
   @OneToMany(() => Participant, (participant) => participant.user)
   participations!: Participant[];
+
+  @OneToMany(() => EventInvitation, (invitation) => invitation.invitedByUser)
+  sentInvitations!: EventInvitation[];
+
+  @OneToMany(() => EventInvitation, (invitation) => invitation.invitedUser)
+  receivedInvitations!: EventInvitation[];
 }

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -455,7 +455,7 @@ describe('Invitations lifecycle (e2e)', () => {
     await request(httpServer)
       .post(`/invitations/${invitationToDeclineId}/decline`)
       .set('Authorization', 'Bearer invitee-token')
-      .expect(201)
+      .expect(200)
       .expect((response) => {
         expect(response.body).toEqual(
           expect.objectContaining({

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -31,6 +31,43 @@ type InvitationRecord = {
   createdAt: Date;
 };
 
+type TestAuthUser = {
+  sub: string;
+  email: string;
+};
+
+function resolveUserFromToken(
+  token: string | undefined,
+  users: {
+    organizer: { id: string; email: string };
+    invitee: { id: string; email: string };
+    stranger: { id: string; email: string };
+  },
+): TestAuthUser | undefined {
+  if (token === 'organizer-token') {
+    return {
+      sub: users.organizer.id,
+      email: users.organizer.email,
+    };
+  }
+
+  if (token === 'invitee-token') {
+    return {
+      sub: users.invitee.id,
+      email: users.invitee.email,
+    };
+  }
+
+  if (token === 'stranger-token') {
+    return {
+      sub: users.stranger.id,
+      email: users.stranger.email,
+    };
+  }
+
+  return undefined;
+}
+
 describe('Invitations lifecycle (e2e)', () => {
   let app: INestApplication;
 
@@ -263,7 +300,7 @@ describe('Invitations lifecycle (e2e)', () => {
     canActivate(context: ExecutionContext): boolean {
       const requestContext = context.switchToHttp().getRequest<{
         headers: Record<string, string | undefined>;
-        user?: { sub: string; email: string };
+        user?: TestAuthUser;
       }>();
 
       const authorization = requestContext.headers.authorization;
@@ -271,27 +308,9 @@ describe('Invitations lifecycle (e2e)', () => {
         ? authorization.slice(7)
         : undefined;
 
-      if (token === 'organizer-token') {
-        requestContext.user = {
-          sub: users.organizer.id,
-          email: users.organizer.email,
-        };
-        return true;
-      }
-
-      if (token === 'invitee-token') {
-        requestContext.user = {
-          sub: users.invitee.id,
-          email: users.invitee.email,
-        };
-        return true;
-      }
-
-      if (token === 'stranger-token') {
-        requestContext.user = {
-          sub: users.stranger.id,
-          email: users.stranger.email,
-        };
+      const resolvedUser = resolveUserFromToken(token, users);
+      if (resolvedUser) {
+        requestContext.user = resolvedUser;
         return true;
       }
 
@@ -341,7 +360,7 @@ describe('Invitations lifecycle (e2e)', () => {
       (
         req: {
           headers: Record<string, string | string[] | undefined>;
-          user?: { sub: string; email: string };
+          user?: TestAuthUser;
         },
         _res: unknown,
         next: () => void,
@@ -352,26 +371,7 @@ describe('Invitations lifecycle (e2e)', () => {
             ? authHeader.slice(7)
             : undefined;
 
-        if (token === 'organizer-token') {
-          req.user = {
-            sub: users.organizer.id,
-            email: users.organizer.email,
-          };
-        }
-
-        if (token === 'invitee-token') {
-          req.user = {
-            sub: users.invitee.id,
-            email: users.invitee.email,
-          };
-        }
-
-        if (token === 'stranger-token') {
-          req.user = {
-            sub: users.stranger.id,
-            email: users.stranger.email,
-          };
-        }
+        req.user = resolveUserFromToken(token, users);
 
         next();
       },

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -128,6 +128,20 @@ describe('Invitations lifecycle (e2e)', () => {
     delete: jest.fn(() => ({ affected: 1 })),
   };
 
+  const transactionManager = {
+    getRepository: jest.fn((entity: unknown) => {
+      if (entity === EventInvitation) {
+        return invitationsRepository;
+      }
+
+      if (entity === Participant) {
+        return participantsRepository;
+      }
+
+      return undefined;
+    }),
+  };
+
   const invitationsRepository = {
     create: jest.fn((payload: Record<string, unknown>) => payload),
     find: jest.fn(
@@ -186,6 +200,30 @@ describe('Invitations lifecycle (e2e)', () => {
 
       return invitations[existingIndex];
     }),
+    update: jest.fn(
+      (
+        where: {
+          id: string;
+          invitedUserId: string;
+          status: EventInvitationStatus;
+        },
+        values: { status: EventInvitationStatus },
+      ) => {
+        const invitation = invitations.find(
+          (row) =>
+            row.id === where.id &&
+            row.invitedUserId === where.invitedUserId &&
+            row.status === where.status,
+        );
+
+        if (!invitation) {
+          return { affected: 0 };
+        }
+
+        invitation.status = values.status;
+        return { affected: 1 };
+      },
+    ),
     delete: jest.fn(({ id, eventId }: { id: string; eventId: string }) => {
       const index = invitations.findIndex(
         (invitation) => invitation.id === id && invitation.eventId === eventId,
@@ -197,6 +235,15 @@ describe('Invitations lifecycle (e2e)', () => {
 
       return { affected: index >= 0 ? 1 : 0 };
     }),
+    manager: {
+      transaction: jest.fn(
+        (
+          callback: (
+            manager: typeof transactionManager,
+          ) => Promise<unknown> | unknown,
+        ) => Promise.resolve(callback(transactionManager)),
+      ),
+    },
   };
 
   const usersRepository = {

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -433,7 +433,7 @@ describe('Invitations lifecycle (e2e)', () => {
     await request(httpServer)
       .post(`/invitations/${invitationToAcceptId}/accept`)
       .set('Authorization', 'Bearer invitee-token')
-      .expect(201)
+      .expect(200)
       .expect((response) => {
         expect(response.body).toEqual(
           expect.objectContaining({

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -165,20 +165,6 @@ describe('Invitations lifecycle (e2e)', () => {
     delete: jest.fn(() => ({ affected: 1 })),
   };
 
-  const transactionManager = {
-    getRepository: jest.fn((entity: unknown) => {
-      if (entity === EventInvitation) {
-        return invitationsRepository;
-      }
-
-      if (entity === Participant) {
-        return participantsRepository;
-      }
-
-      return undefined;
-    }),
-  };
-
   const invitationsRepository = {
     create: jest.fn((payload: Record<string, unknown>) => payload),
     find: jest.fn(
@@ -273,15 +259,28 @@ describe('Invitations lifecycle (e2e)', () => {
       return { affected: index >= 0 ? 1 : 0 };
     }),
     manager: {
-      transaction: jest.fn(
-        (
-          callback: (
-            manager: typeof transactionManager,
-          ) => Promise<unknown> | unknown,
-        ) => Promise.resolve(callback(transactionManager)),
-      ),
+      transaction: jest.fn(),
     },
   };
+
+  const transactionManager = {
+    getRepository: jest.fn((entity: unknown): unknown => {
+      if (entity === EventInvitation) {
+        return invitationsRepository;
+      }
+
+      if (entity === Participant) {
+        return participantsRepository;
+      }
+
+      return undefined;
+    }),
+  };
+
+  invitationsRepository.manager.transaction.mockImplementation(
+    (callback: (manager: typeof transactionManager) => unknown) =>
+      Promise.resolve(callback(transactionManager)),
+  );
 
   const usersRepository = {
     findOne: jest.fn(

--- a/backend/test/invitations.e2e-spec.ts
+++ b/backend/test/invitations.e2e-spec.ts
@@ -1,0 +1,426 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { JwtAuthGuard } from '../src/auth/jwt-auth.guard';
+import { EventsController } from '../src/events/events.controller';
+import { Event, EventVisibility } from '../src/events/entities/event.entity';
+import { EventsService } from '../src/events/events.service';
+import { InvitationsLifecycleController } from '../src/invitations/invitations-lifecycle.controller';
+import { InvitationsController } from '../src/invitations/invitations.controller';
+import {
+  EventInvitation,
+  EventInvitationStatus,
+} from '../src/invitations/entities/event-invitation.entity';
+import { InvitationsService } from '../src/invitations/invitations.service';
+import { Participant } from '../src/participants/entities/participant.entity';
+import { Tag } from '../src/tags/entities/tag.entity';
+import { User } from '../src/users/entities/user.entity';
+
+type InvitationRecord = {
+  id: string;
+  eventId: string;
+  invitedByUserId: string;
+  invitedUserId: string;
+  status: EventInvitationStatus;
+  createdAt: Date;
+};
+
+describe('Invitations lifecycle (e2e)', () => {
+  let app: INestApplication;
+
+  const users = {
+    organizer: {
+      id: '11111111-1111-4111-8111-111111111111',
+      email: 'organizer@example.com',
+      name: 'Organizer',
+    },
+    invitee: {
+      id: '22222222-2222-4222-8222-222222222222',
+      email: 'invitee@example.com',
+      name: 'Invitee',
+    },
+    stranger: {
+      id: '33333333-3333-4333-8333-333333333333',
+      email: 'stranger@example.com',
+      name: 'Stranger',
+    },
+  };
+
+  const privateEventId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const invitationToAcceptId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const invitationToDeclineId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+  const invitations: InvitationRecord[] = [];
+  const participants: Array<{ id: string; eventId: string; userId: string }> =
+    [];
+
+  const eventsRepository = {
+    findOne: jest.fn(({ where }: { where: { id: string } }) => {
+      if (where.id !== privateEventId) {
+        return null;
+      }
+
+      return {
+        id: privateEventId,
+        title: 'Private party',
+        visibility: EventVisibility.PRIVATE,
+        organizerId: users.organizer.id,
+        organizer: users.organizer,
+        participants: participants.map((participant) => ({
+          userId: participant.userId,
+          user: Object.values(users).find(
+            (user) => user.id === participant.userId,
+          ),
+        })),
+        invitations: invitations.filter(
+          (invitation) => invitation.eventId === privateEventId,
+        ),
+        tags: [],
+        eventDate: new Date('2026-12-01T18:00:00.000Z'),
+      };
+    }),
+    find: jest.fn(() => []),
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    save: jest.fn((payload: Record<string, unknown>) => payload),
+    delete: jest.fn(() => ({ affected: 1 })),
+    manager: {
+      transaction: jest.fn(),
+    },
+  };
+
+  const participantsRepository = {
+    findOne: jest.fn(
+      ({ where }: { where: { eventId: string; userId: string } }) =>
+        participants.find(
+          (participant) =>
+            participant.eventId === where.eventId &&
+            participant.userId === where.userId,
+        ) ?? null,
+    ),
+    count: jest.fn(() => participants.length),
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    save: jest.fn((payload: { eventId: string; userId: string }) => {
+      const existing = participants.find(
+        (participant) =>
+          participant.eventId === payload.eventId &&
+          participant.userId === payload.userId,
+      );
+
+      if (existing) {
+        return existing;
+      }
+
+      const row = {
+        id: `participant-${participants.length + 1}`,
+        eventId: payload.eventId,
+        userId: payload.userId,
+      };
+
+      participants.push(row);
+      return row;
+    }),
+    delete: jest.fn(() => ({ affected: 1 })),
+  };
+
+  const invitationsRepository = {
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    find: jest.fn(
+      ({ where }: { where: { eventId?: string; invitedUserId?: string } }) => {
+        if (where.eventId) {
+          return invitations.filter(
+            (invitation) => invitation.eventId === where.eventId,
+          );
+        }
+
+        if (where.invitedUserId) {
+          return invitations.filter(
+            (invitation) => invitation.invitedUserId === where.invitedUserId,
+          );
+        }
+
+        return [];
+      },
+    ),
+    findOne: jest.fn(
+      ({
+        where,
+      }: {
+        where: { id?: string; eventId?: string; invitedUserId?: string };
+      }) =>
+        invitations.find((invitation) => {
+          const idMatches = where.id ? invitation.id === where.id : true;
+          const eventMatches = where.eventId
+            ? invitation.eventId === where.eventId
+            : true;
+          const userMatches = where.invitedUserId
+            ? invitation.invitedUserId === where.invitedUserId
+            : true;
+
+          return idMatches && eventMatches && userMatches;
+        }) ?? null,
+    ),
+    save: jest.fn((payload: InvitationRecord) => {
+      const existingIndex = invitations.findIndex(
+        (invitation) => invitation.id === payload.id,
+      );
+
+      if (existingIndex === -1) {
+        const row: InvitationRecord = {
+          ...payload,
+          createdAt: payload.createdAt ?? new Date(),
+        };
+        invitations.push(row);
+        return row;
+      }
+
+      invitations[existingIndex] = {
+        ...invitations[existingIndex],
+        ...payload,
+      };
+
+      return invitations[existingIndex];
+    }),
+    delete: jest.fn(({ id, eventId }: { id: string; eventId: string }) => {
+      const index = invitations.findIndex(
+        (invitation) => invitation.id === id && invitation.eventId === eventId,
+      );
+
+      if (index >= 0) {
+        invitations.splice(index, 1);
+      }
+
+      return { affected: index >= 0 ? 1 : 0 };
+    }),
+  };
+
+  const usersRepository = {
+    findOne: jest.fn(
+      ({ where }: { where: { id: string } }) =>
+        Object.values(users).find((user) => user.id === where.id) ?? null,
+    ),
+  };
+
+  const tagsRepository = {
+    find: jest.fn(() => []),
+    create: jest.fn((payload: Record<string, unknown>) => payload),
+    save: jest.fn((payload: Record<string, unknown>) => payload),
+  };
+
+  const authGuard: CanActivate = {
+    canActivate(context: ExecutionContext): boolean {
+      const requestContext = context.switchToHttp().getRequest<{
+        headers: Record<string, string | undefined>;
+        user?: { sub: string; email: string };
+      }>();
+
+      const authorization = requestContext.headers.authorization;
+      const token = authorization?.startsWith('Bearer ')
+        ? authorization.slice(7)
+        : undefined;
+
+      if (token === 'organizer-token') {
+        requestContext.user = {
+          sub: users.organizer.id,
+          email: users.organizer.email,
+        };
+        return true;
+      }
+
+      if (token === 'invitee-token') {
+        requestContext.user = {
+          sub: users.invitee.id,
+          email: users.invitee.email,
+        };
+        return true;
+      }
+
+      if (token === 'stranger-token') {
+        requestContext.user = {
+          sub: users.stranger.id,
+          email: users.stranger.email,
+        };
+        return true;
+      }
+
+      throw new UnauthorizedException();
+    },
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [
+        EventsController,
+        InvitationsController,
+        InvitationsLifecycleController,
+      ],
+      providers: [
+        EventsService,
+        InvitationsService,
+        {
+          provide: getRepositoryToken(Event),
+          useValue: eventsRepository,
+        },
+        {
+          provide: getRepositoryToken(Participant),
+          useValue: participantsRepository,
+        },
+        {
+          provide: getRepositoryToken(Tag),
+          useValue: tagsRepository,
+        },
+        {
+          provide: getRepositoryToken(EventInvitation),
+          useValue: invitationsRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepository,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(authGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.use(
+      (
+        req: {
+          headers: Record<string, string | string[] | undefined>;
+          user?: { sub: string; email: string };
+        },
+        _res: unknown,
+        next: () => void,
+      ) => {
+        const authHeader = req.headers.authorization;
+        const token =
+          typeof authHeader === 'string' && authHeader.startsWith('Bearer ')
+            ? authHeader.slice(7)
+            : undefined;
+
+        if (token === 'organizer-token') {
+          req.user = {
+            sub: users.organizer.id,
+            email: users.organizer.email,
+          };
+        }
+
+        if (token === 'invitee-token') {
+          req.user = {
+            sub: users.invitee.id,
+            email: users.invitee.email,
+          };
+        }
+
+        if (token === 'stranger-token') {
+          req.user = {
+            sub: users.stranger.id,
+            email: users.stranger.email,
+          };
+        }
+
+        next();
+      },
+    );
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    invitations.length = 0;
+    participants.length = 0;
+
+    invitations.push(
+      {
+        id: invitationToAcceptId,
+        eventId: privateEventId,
+        invitedByUserId: users.organizer.id,
+        invitedUserId: users.invitee.id,
+        status: EventInvitationStatus.PENDING,
+        createdAt: new Date('2026-10-01T10:00:00.000Z'),
+      },
+      {
+        id: invitationToDeclineId,
+        eventId: privateEventId,
+        invitedByUserId: users.organizer.id,
+        invitedUserId: users.invitee.id,
+        status: EventInvitationStatus.PENDING,
+        createdAt: new Date('2026-10-01T11:00:00.000Z'),
+      },
+    );
+
+    jest.clearAllMocks();
+  });
+
+  it('GET /invitations/me returns invitations for current user', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(httpServer)
+      .get('/invitations/me')
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(200);
+
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body).toHaveLength(2);
+  });
+
+  it('POST /invitations/:id/accept grants private event access', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(httpServer)
+      .get(`/events/${privateEventId}`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(403);
+
+    await request(httpServer)
+      .post(`/invitations/${invitationToAcceptId}/accept`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(201)
+      .expect((response) => {
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            id: invitationToAcceptId,
+            status: EventInvitationStatus.ACCEPTED,
+          }),
+        );
+      });
+
+    await request(httpServer)
+      .get(`/events/${privateEventId}`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(200);
+  });
+
+  it('POST /invitations/:id/decline sets declined status and keeps private access denied', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(httpServer)
+      .post(`/invitations/${invitationToDeclineId}/decline`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(201)
+      .expect((response) => {
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            id: invitationToDeclineId,
+            status: EventInvitationStatus.DECLINED,
+          }),
+        );
+      });
+
+    await request(httpServer)
+      .get(`/events/${privateEventId}`)
+      .set('Authorization', 'Bearer invitee-token')
+      .expect(403);
+  });
+});

--- a/docs/frontend-state.md
+++ b/docs/frontend-state.md
@@ -11,6 +11,7 @@ This project intentionally uses both Redux Toolkit and Zustand.
 
 - Auth/session state (`auth` slice).
 - Events domain data (`events` slice): lists, selected event, request status, API errors.
+- Invitations domain data (`invitations` slice): organizer event invitations, invitee list, action statuses, API errors.
 - Async actions that call backend APIs.
 - Any state required across multiple pages and business flows.
 
@@ -36,3 +37,4 @@ This project intentionally uses both Redux Toolkit and Zustand.
 - Redux hooks: `frontend/src/app/hooks.ts`
 - Zustand assistant UI store: `frontend/src/features/events/model/assistantUiStore.ts`
 - Redux events domain slice: `frontend/src/features/events/model/eventsSlice.ts`
+- Redux invitations domain slice: `frontend/src/features/invitations/model/invitationsSlice.ts`

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -121,6 +121,34 @@ Acceptance Criteria:
 
 Priority: Could
 
+## Epic: Private Invitations
+
+### Story US-11: Manage private invitations as organizer
+
+As an organizer of a private event, I want to invite and revoke users so that I can control event access before participation.
+
+Acceptance Criteria:
+
+- Organizer can create an invitation for a valid user on a private event.
+- Organizer can view event invitations list with statuses.
+- Organizer can revoke an existing invitation.
+- Non-organizers cannot manage invitations for the event.
+
+Priority: Must
+
+### Story US-12: Respond to invitations as invitee
+
+As an invited user, I want to review and accept or decline invitations so that I can control whether I join private events.
+
+Acceptance Criteria:
+
+- Invitee can view personal invitation list.
+- Invitee can accept or decline only their own pending invitation.
+- Invitee sees private-event preview sanitized until invitation is accepted.
+- Accepted invitations allow opening related event details from `My Invitations`.
+
+Priority: Must
+
 ## Traceability
 
 Story-to-module mapping (frontend and backend ownership):
@@ -137,6 +165,8 @@ Story-to-module mapping (frontend and backend ownership):
 | US-08 | delete modal/action in event details flow                                                                                                                              | `backend/src/events/events.controller.ts`, `backend/src/events/events.service.ts`                                        |
 | US-09 | assistant panel/components and request flow in `frontend/src/components/assistant/*`, `frontend/src/features/events/model/*`, and `frontend/src/features/events/api/*` | `backend/src/assistant/*`                                                                                                |
 | US-10 | recent prompts persistence in assistant UI state                                                                                                                       | `backend/src/assistant/*` (answer flow), local persistence on frontend                                                   |
+| US-11 | organizer invitation UI in `frontend/src/features/invitations/ui/*`, event details integration in `frontend/src/features/events/ui/event-details/*`                | `backend/src/invitations/*`, private event checks in `backend/src/events/*`                                              |
+| US-12 | `frontend/src/pages/MyInvitationsPage*`, invitation state/actions in `frontend/src/features/invitations/model/*`                                                    | `backend/src/invitations/*`, participant sync in `backend/src/participants/*`                                            |
 
 ## Status Tracking
 
@@ -152,3 +182,5 @@ Story-to-module mapping (frontend and backend ownership):
 | US-08 | Done (MVP) | Organizer delete-event flow implemented.                  |
 | US-09 | Done (MVP) | Assistant question/answer flow implemented.               |
 | US-10 | Done (MVP) | Recent prompts persistence supported in assistant UX.     |
+| US-11 | Done (MVP) | Organizer can manage private invitations end-to-end.      |
+| US-12 | Done (MVP) | Invitee accept/decline and invitation list flows shipped. |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,6 +9,8 @@ Main features:
 - authentication flows
 - public event discovery
 - event details and participation actions
+- organizer private invitations panel on event details (invite and revoke)
+- `My Invitations` page for invitees (accept and decline)
 - event creation and editing
 - calendar-based "My Events" page
 - AI assistant UI with suggestions and recent questions
@@ -88,6 +90,12 @@ Covered flows include:
 - assistant visibility for unauthenticated users
 - predefined assistant suggestions
 - persisted recent assistant questions via `localStorage`
+
+Focused invitations page suite:
+
+```bash
+npx vitest run src/pages/MyInvitationsPage.test.tsx
+```
 
 ## Storybook
 

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -10,6 +10,7 @@ import { EventDetailsPage } from "../pages/EventDetailsPage";
 import { EventsPage } from "../pages/EventsPage";
 import { LoginPage } from "../pages/LoginPage";
 import { MyEventsPage } from "../pages/MyEventsPage";
+import { MyInvitationsPage } from "../pages/MyInvitationsPage";
 import { RegisterPage } from "../pages/RegisterPage";
 import { APP_ROUTES } from "./routes";
 
@@ -50,6 +51,14 @@ const appRoutes = [
         element: (
           <ProtectedRoute>
             <MyEventsPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: APP_ROUTES.myInvitations,
+        element: (
+          <ProtectedRoute>
+            <MyInvitationsPage />
           </ProtectedRoute>
         ),
       },

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -4,6 +4,7 @@ export const APP_ROUTES = {
   eventDetails: "/events/:id",
   createEvent: "/events/create",
   myEvents: "/my-events",
+  myInvitations: "/my-invitations",
   login: "/login",
   register: "/register",
   wildcard: "*",

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,14 +1,15 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { authReducer } from "../features/auth/authSlice";
 import { eventsReducer } from "../features/events/model/eventsSlice";
+import { invitationsReducer } from "../features/invitations/model/invitationsSlice";
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     events: eventsReducer,
+    invitations: invitationsReducer,
   },
 });
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
-

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -25,6 +25,7 @@ export function MainLayout() {
     (pathname.startsWith("/events/") && pathname !== "/events/create");
   const isCreateActive = pathname === "/events/create";
   const isMyEventsActive = pathname === "/my-events";
+  const isMyInvitationsActive = pathname === "/my-invitations";
 
   const navItemClass = (isActive: boolean) =>
     isActive
@@ -163,6 +164,39 @@ export function MainLayout() {
                 <path d="M3 10H21" stroke="currentColor" strokeWidth="2" />
               </svg>
               My Events
+            </Link>
+            <Link
+              to="/my-invitations"
+              className={navItemClass(isMyInvitationsActive)}
+            >
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 7H20"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+                <path
+                  d="M4 12H20"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+                <path
+                  d="M4 17H14"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+              </svg>
+              My Invitations
             </Link>
             <Link
               to="/events/create"

--- a/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
+++ b/frontend/src/features/events/ui/event-details/EventDetailsInteractionSection.tsx
@@ -11,6 +11,7 @@ import { EditIcon } from "../../../../components/ui/icons/EditIcon";
 import { TrashIcon } from "../../../../components/ui/icons/TrashIcon";
 import { EventEditForm } from "./EventEditForm";
 import type { EventEditFormValues } from "./EventEditForm";
+import { OrganizerInvitationsPanel } from "../../../invitations/ui/OrganizerInvitationsPanel";
 
 type EventDetailsInteractionSectionProps = {
   currentEvent: EventItem;
@@ -270,6 +271,12 @@ export function EventDetailsInteractionSection({
       </div>
 
       {error ? <FormErrorText className="mt-4">{error}</FormErrorText> : null}
+
+      <OrganizerInvitationsPanel
+        eventId={currentEvent.id}
+        isPrivateEvent={currentEvent.visibility === "private"}
+        isOrganizer={isOrganizer}
+      />
 
       {isOrganizer && isEditing ? (
         <EventEditForm

--- a/frontend/src/features/invitations/api/invitationsApi.ts
+++ b/frontend/src/features/invitations/api/invitationsApi.ts
@@ -1,0 +1,63 @@
+import { api } from "../../../shared/api/client";
+import type { InvitationItem } from "../../../types/invitation";
+
+export const fetchEventInvitationsRequest = async (
+  eventId: string,
+): Promise<InvitationItem[]> => {
+  const response = await api.get<InvitationItem[]>(
+    `/events/${eventId}/invitations`,
+  );
+  return response.data;
+};
+
+export const createInvitationRequest = async (payload: {
+  eventId: string;
+  invitedUserId: string;
+}): Promise<InvitationItem> => {
+  const response = await api.post<InvitationItem>(
+    `/events/${payload.eventId}/invitations`,
+    {
+      invitedUserId: payload.invitedUserId,
+    },
+  );
+
+  return response.data;
+};
+
+export const revokeInvitationRequest = async (payload: {
+  eventId: string;
+  invitationId: string;
+}): Promise<void> => {
+  await api.delete(
+    `/events/${payload.eventId}/invitations/${payload.invitationId}`,
+  );
+};
+
+export const fetchMyInvitationsRequest = async (): Promise<
+  InvitationItem[]
+> => {
+  const response = await api.get<InvitationItem[]>("/invitations/me");
+  return response.data;
+};
+
+export const acceptInvitationRequest = async (
+  invitationId: string,
+): Promise<InvitationItem> => {
+  const response = await api.post<InvitationItem>(
+    `/invitations/${invitationId}/accept`,
+    {},
+  );
+
+  return response.data;
+};
+
+export const declineInvitationRequest = async (
+  invitationId: string,
+): Promise<InvitationItem> => {
+  const response = await api.post<InvitationItem>(
+    `/invitations/${invitationId}/decline`,
+    {},
+  );
+
+  return response.data;
+};

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -131,6 +131,7 @@ const invitationsSlice = createSlice({
           current,
           action.payload.invitation,
         );
+        state.eventErrorById[action.payload.eventId] = null;
       })
       .addCase(createInvitation.rejected, (state, action) => {
         state.actionStatusByKey[`create:${action.meta.arg.eventId}`] = "failed";
@@ -148,6 +149,7 @@ const invitationsSlice = createSlice({
         state.byEventId[action.payload.eventId] = current.filter(
           (invitation) => invitation.id !== action.payload.invitationId,
         );
+        state.eventErrorById[action.payload.eventId] = null;
       })
       .addCase(revokeInvitation.rejected, (state, action) => {
         state.actionStatusByKey[`revoke:${action.meta.arg.invitationId}`] =

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -12,11 +12,11 @@ import {
 
 type InvitationsState = {
   byEventId: Record<string, InvitationItem[]>;
-  eventStatusById: Record<string, "idle" | "loading" | "failed">;
+  eventStatusById: Partial<Record<string, "idle" | "loading" | "failed">>;
   myInvitations: InvitationItem[];
   myStatus: "idle" | "loading" | "failed";
-  actionStatusByKey: Record<string, "idle" | "loading" | "failed">;
-  eventErrorById: Record<string, string | null>;
+  actionStatusByKey: Partial<Record<string, "idle" | "loading" | "failed">>;
+  eventErrorById: Partial<Record<string, string | null>>;
   myError: string | null;
   actionError: string | null;
 };

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -107,10 +107,12 @@ const invitationsSlice = createSlice({
       .addCase(fetchInvitationsForEvent.pending, (state, action) => {
         state.eventStatusById[action.meta.arg] = "loading";
         state.eventErrorById[action.meta.arg] = null;
+        state.actionError = null; // Clear global action error on event invitations load
       })
       .addCase(fetchInvitationsForEvent.fulfilled, (state, action) => {
         state.eventStatusById[action.payload.eventId] = "idle";
         state.byEventId[action.payload.eventId] = action.payload.invitations;
+        state.actionError = null; // Also clear error after successful load
       })
       .addCase(fetchInvitationsForEvent.rejected, (state, action) => {
         const eventId = action.meta.arg;

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -1,0 +1,200 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { logoutUser } from "../../auth/authSlice";
+import type { InvitationItem } from "../../../types/invitation";
+import {
+  acceptInvitationRequest,
+  createInvitationRequest,
+  declineInvitationRequest,
+  fetchEventInvitationsRequest,
+  fetchMyInvitationsRequest,
+  revokeInvitationRequest,
+} from "../api/invitationsApi";
+
+type InvitationsState = {
+  byEventId: Record<string, InvitationItem[]>;
+  eventStatusById: Record<string, "idle" | "loading" | "failed">;
+  myInvitations: InvitationItem[];
+  myStatus: "idle" | "loading" | "failed";
+  actionStatusByKey: Record<string, "idle" | "loading" | "failed">;
+  eventErrorById: Record<string, string | null>;
+  myError: string | null;
+  actionError: string | null;
+};
+
+const initialState: InvitationsState = {
+  byEventId: {},
+  eventStatusById: {},
+  myInvitations: [],
+  myStatus: "idle",
+  actionStatusByKey: {},
+  eventErrorById: {},
+  myError: null,
+  actionError: null,
+};
+
+const upsertInvitation = (
+  invitations: InvitationItem[],
+  invitation: InvitationItem,
+): InvitationItem[] => {
+  const existingIndex = invitations.findIndex(
+    (item) => item.id === invitation.id,
+  );
+
+  if (existingIndex === -1) {
+    return [invitation, ...invitations];
+  }
+
+  const next = [...invitations];
+  next[existingIndex] = invitation;
+  return next;
+};
+
+export const fetchInvitationsForEvent = createAsyncThunk(
+  "invitations/fetchForEvent",
+  async (eventId: string) => {
+    const invitations = await fetchEventInvitationsRequest(eventId);
+    return { eventId, invitations };
+  },
+);
+
+export const createInvitation = createAsyncThunk(
+  "invitations/create",
+  async (payload: { eventId: string; invitedUserId: string }) => {
+    const invitation = await createInvitationRequest(payload);
+    return {
+      eventId: payload.eventId,
+      invitation,
+    };
+  },
+);
+
+export const revokeInvitation = createAsyncThunk(
+  "invitations/revoke",
+  async (payload: { eventId: string; invitationId: string }) => {
+    await revokeInvitationRequest(payload);
+    return payload;
+  },
+);
+
+export const fetchMyInvitations = createAsyncThunk(
+  "invitations/fetchMy",
+  async () => {
+    return fetchMyInvitationsRequest();
+  },
+);
+
+export const acceptInvitation = createAsyncThunk(
+  "invitations/accept",
+  async (invitationId: string) => {
+    return acceptInvitationRequest(invitationId);
+  },
+);
+
+export const declineInvitation = createAsyncThunk(
+  "invitations/decline",
+  async (invitationId: string) => {
+    return declineInvitationRequest(invitationId);
+  },
+);
+
+const invitationsSlice = createSlice({
+  name: "invitations",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(logoutUser.fulfilled, () => initialState)
+      .addCase(fetchInvitationsForEvent.pending, (state, action) => {
+        state.eventStatusById[action.meta.arg] = "loading";
+        state.eventErrorById[action.meta.arg] = null;
+      })
+      .addCase(fetchInvitationsForEvent.fulfilled, (state, action) => {
+        state.eventStatusById[action.payload.eventId] = "idle";
+        state.byEventId[action.payload.eventId] = action.payload.invitations;
+      })
+      .addCase(fetchInvitationsForEvent.rejected, (state, action) => {
+        const eventId = action.meta.arg;
+        state.eventStatusById[eventId] = "failed";
+        state.eventErrorById[eventId] = "Failed to load invitations";
+      })
+      .addCase(createInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`create:${action.meta.arg.eventId}`] =
+          "loading";
+        state.actionError = null;
+      })
+      .addCase(createInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`create:${action.payload.eventId}`] = "idle";
+        const current = state.byEventId[action.payload.eventId] ?? [];
+        state.byEventId[action.payload.eventId] = upsertInvitation(
+          current,
+          action.payload.invitation,
+        );
+      })
+      .addCase(createInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`create:${action.meta.arg.eventId}`] = "failed";
+        state.actionError = "Failed to create invitation";
+      })
+      .addCase(revokeInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`revoke:${action.meta.arg.invitationId}`] =
+          "loading";
+        state.actionError = null;
+      })
+      .addCase(revokeInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`revoke:${action.payload.invitationId}`] =
+          "idle";
+        const current = state.byEventId[action.payload.eventId] ?? [];
+        state.byEventId[action.payload.eventId] = current.filter(
+          (invitation) => invitation.id !== action.payload.invitationId,
+        );
+      })
+      .addCase(revokeInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`revoke:${action.meta.arg.invitationId}`] =
+          "failed";
+        state.actionError = "Failed to revoke invitation";
+      })
+      .addCase(fetchMyInvitations.pending, (state) => {
+        state.myStatus = "loading";
+        state.myError = null;
+      })
+      .addCase(fetchMyInvitations.fulfilled, (state, action) => {
+        state.myStatus = "idle";
+        state.myInvitations = action.payload;
+      })
+      .addCase(fetchMyInvitations.rejected, (state) => {
+        state.myStatus = "failed";
+        state.myError = "Failed to load my invitations";
+      })
+      .addCase(acceptInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "loading";
+        state.actionError = null;
+      })
+      .addCase(acceptInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`respond:${action.payload.id}`] = "idle";
+        state.myInvitations = upsertInvitation(
+          state.myInvitations,
+          action.payload,
+        );
+      })
+      .addCase(acceptInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "failed";
+        state.actionError = "Failed to accept invitation";
+      })
+      .addCase(declineInvitation.pending, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "loading";
+        state.actionError = null;
+      })
+      .addCase(declineInvitation.fulfilled, (state, action) => {
+        state.actionStatusByKey[`respond:${action.payload.id}`] = "idle";
+        state.myInvitations = upsertInvitation(
+          state.myInvitations,
+          action.payload,
+        );
+      })
+      .addCase(declineInvitation.rejected, (state, action) => {
+        state.actionStatusByKey[`respond:${action.meta.arg}`] = "failed";
+        state.actionError = "Failed to decline invitation";
+      });
+  },
+});
+
+export const invitationsReducer = invitationsSlice.reducer;

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -107,10 +107,12 @@ const invitationsSlice = createSlice({
       .addCase(fetchInvitationsForEvent.pending, (state, action) => {
         state.eventStatusById[action.meta.arg] = "loading";
         state.eventErrorById[action.meta.arg] = null;
+        state.actionError = null; // Clear global action error on event invitations load
       })
       .addCase(fetchInvitationsForEvent.fulfilled, (state, action) => {
         state.eventStatusById[action.payload.eventId] = "idle";
         state.byEventId[action.payload.eventId] = action.payload.invitations;
+        state.actionError = null; // Also clear error after successful load
       })
       .addCase(fetchInvitationsForEvent.rejected, (state, action) => {
         const eventId = action.meta.arg;
@@ -155,6 +157,7 @@ const invitationsSlice = createSlice({
       .addCase(fetchMyInvitations.pending, (state) => {
         state.myStatus = "loading";
         state.myError = null;
+        state.actionError = null; // Clear global action error on my invitations load
       })
       .addCase(fetchMyInvitations.fulfilled, (state, action) => {
         state.myStatus = "idle";

--- a/frontend/src/features/invitations/model/invitationsSlice.ts
+++ b/frontend/src/features/invitations/model/invitationsSlice.ts
@@ -45,7 +45,14 @@ const upsertInvitation = (
   }
 
   const next = [...invitations];
-  next[existingIndex] = invitation;
+  const existingInvitation = next[existingIndex];
+  next[existingIndex] = {
+    ...existingInvitation,
+    ...invitation,
+    event: invitation.event ?? existingInvitation.event,
+    invitedByUser: invitation.invitedByUser ?? existingInvitation.invitedByUser,
+    invitedUser: invitation.invitedUser ?? existingInvitation.invitedUser,
+  };
   return next;
 };
 

--- a/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
+++ b/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
@@ -90,7 +90,7 @@ export function OrganizerInvitationsPanel({
           onChange={(event) => setInvitedUserId(event.target.value)}
           type="text"
           placeholder="Invited user UUID"
-          className="min-w-70 flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+          className="min-w-[17.5rem] flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
         />
         <Button
           type="submit"

--- a/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
+++ b/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
@@ -41,6 +41,7 @@ export function OrganizerInvitationsPanel({
     (state) =>
       state.invitations.actionStatusByKey[`create:${eventId}`] === "loading",
   );
+  const inviteInputId = `invited-user-id-${eventId}`;
   const [invitedUserId, setInvitedUserId] = useState("");
 
   useEffect(() => {
@@ -85,7 +86,11 @@ export function OrganizerInvitationsPanel({
         onSubmit={(event) => void handleInvite(event)}
         className="mt-4 flex flex-wrap gap-2"
       >
+        <label htmlFor={inviteInputId} className="sr-only">
+          Invited user UUID
+        </label>
         <input
+          id={inviteInputId}
           value={invitedUserId}
           onChange={(event) => setInvitedUserId(event.target.value)}
           type="text"
@@ -112,7 +117,7 @@ export function OrganizerInvitationsPanel({
         <FormErrorText className="mt-2">{actionError}</FormErrorText>
       ) : null}
 
-      {invitations.length === 0 && listStatus !== "loading" ? (
+      {listStatus === "idle" && !listError && invitations.length === 0 ? (
         <p className="mt-4 text-sm text-slate-600">No invitations yet.</p>
       ) : null}
 

--- a/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
+++ b/frontend/src/features/invitations/ui/OrganizerInvitationsPanel.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import { useAppDispatch, useAppSelector } from "../../../app/hooks";
+import {
+  createInvitation,
+  fetchInvitationsForEvent,
+  revokeInvitation,
+} from "../model/invitationsSlice";
+import { Button } from "../../../components/ui/Button";
+import { FormErrorText } from "../../../components/ui/FormErrorText";
+import type { InvitationItem } from "../../../types/invitation";
+
+type OrganizerInvitationsPanelProps = {
+  eventId: string;
+  isPrivateEvent: boolean;
+  isOrganizer: boolean;
+};
+
+const EMPTY_INVITATIONS: InvitationItem[] = [];
+
+export function OrganizerInvitationsPanel({
+  eventId,
+  isPrivateEvent,
+  isOrganizer,
+}: OrganizerInvitationsPanelProps) {
+  const dispatch = useAppDispatch();
+  const invitations = useAppSelector(
+    (state) => state.invitations.byEventId[eventId] ?? EMPTY_INVITATIONS,
+  );
+  const listStatus = useAppSelector(
+    (state) => state.invitations.eventStatusById[eventId] ?? "idle",
+  );
+  const listError = useAppSelector(
+    (state) => state.invitations.eventErrorById[eventId],
+  );
+  const actionError = useAppSelector((state) => state.invitations.actionError);
+  const actionStatusByKey = useAppSelector(
+    (state) => state.invitations.actionStatusByKey,
+  );
+  const isCreating = useAppSelector(
+    (state) =>
+      state.invitations.actionStatusByKey[`create:${eventId}`] === "loading",
+  );
+  const [invitedUserId, setInvitedUserId] = useState("");
+
+  useEffect(() => {
+    if (isOrganizer && isPrivateEvent) {
+      void dispatch(fetchInvitationsForEvent(eventId));
+    }
+  }, [dispatch, eventId, isOrganizer, isPrivateEvent]);
+
+  const handleInvite = async (submitEvent: FormEvent<HTMLFormElement>) => {
+    submitEvent.preventDefault();
+
+    const nextUserId = invitedUserId.trim();
+    if (!nextUserId) {
+      return;
+    }
+
+    try {
+      await dispatch(
+        createInvitation({
+          eventId,
+          invitedUserId: nextUserId,
+        }),
+      ).unwrap();
+      setInvitedUserId("");
+    } catch {
+      // Error state is handled by Redux slice for consistent UX.
+    }
+  };
+
+  if (!isOrganizer || !isPrivateEvent) {
+    return null;
+  }
+
+  return (
+    <section className="mt-8 rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <h3 className="text-lg font-semibold text-slate-900">Invitations</h3>
+      <p className="mt-1 text-sm text-slate-600">
+        Invite users by their account UUID to join this private event.
+      </p>
+
+      <form
+        onSubmit={(event) => void handleInvite(event)}
+        className="mt-4 flex flex-wrap gap-2"
+      >
+        <input
+          value={invitedUserId}
+          onChange={(event) => setInvitedUserId(event.target.value)}
+          type="text"
+          placeholder="Invited user UUID"
+          className="min-w-70 flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+        />
+        <Button
+          type="submit"
+          disabled={isCreating || invitedUserId.trim().length === 0}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-60"
+        >
+          {isCreating ? "Inviting..." : "Invite"}
+        </Button>
+      </form>
+
+      {listStatus === "loading" ? (
+        <p className="mt-4 text-sm text-slate-600">Loading invitations...</p>
+      ) : null}
+
+      {listError ? (
+        <FormErrorText className="mt-3">{listError}</FormErrorText>
+      ) : null}
+      {actionError ? (
+        <FormErrorText className="mt-2">{actionError}</FormErrorText>
+      ) : null}
+
+      {invitations.length === 0 && listStatus !== "loading" ? (
+        <p className="mt-4 text-sm text-slate-600">No invitations yet.</p>
+      ) : null}
+
+      {invitations.length > 0 ? (
+        <ul className="mt-4 space-y-2">
+          {invitations.map((invitation) => {
+            const isRevoking =
+              actionStatusByKey[`revoke:${invitation.id}`] === "loading";
+
+            return (
+              <li
+                key={invitation.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2"
+              >
+                <div className="text-sm text-slate-800">
+                  <span className="font-medium">
+                    {invitation.invitedUser?.email ?? invitation.invitedUserId}
+                  </span>
+                  <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs uppercase text-slate-600">
+                    {invitation.status}
+                  </span>
+                </div>
+                <Button
+                  type="button"
+                  disabled={isRevoking}
+                  onClick={() => {
+                    void dispatch(
+                      revokeInvitation({
+                        eventId,
+                        invitationId: invitation.id,
+                      }),
+                    );
+                  }}
+                  className="rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-700 hover:bg-red-100 disabled:opacity-60"
+                >
+                  {isRevoking ? "Revoking..." : "Revoke"}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/EventDetailsPage.test.tsx
+++ b/frontend/src/pages/EventDetailsPage.test.tsx
@@ -299,4 +299,80 @@ describe("EventDetailsPage", () => {
       resolveDelete?.();
     });
   });
+
+  it("shows organizer invitations panel for private event and submits invite", async () => {
+    const event = {
+      ...createInitialEvent(),
+      visibility: "private" as const,
+    };
+
+    vi.spyOn(api, "get").mockImplementation(async (url: string) => {
+      if (url === "/events/evt-1") {
+        return { data: event };
+      }
+
+      if (url === "/users/me/events") {
+        return { data: [] };
+      }
+
+      if (url === "/events/evt-1/invitations") {
+        return { data: [] };
+      }
+
+      throw new Error(`Unexpected GET url: ${url}`);
+    });
+
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      data: {
+        id: "inv-1",
+        eventId: "evt-1",
+        invitedByUserId: "org-1",
+        invitedUserId: "usr-2",
+        status: "pending",
+        createdAt: "2099-01-01T00:00:00.000Z",
+      },
+    });
+
+    const store = createTestStore({
+      auth: {
+        token: "test-token",
+        user: { email: "organizer@example.com" },
+        status: "idle",
+        error: null,
+      },
+      events: {
+        publicEvents: [],
+        myEvents: [],
+        selectedEvent: null,
+        status: "idle",
+        error: null,
+        assistantAnswer: null,
+        assistantStatus: "idle",
+        assistantError: null,
+      },
+    });
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/events/evt-1"]}>
+        <Routes>
+          <Route path="/events/:id" element={<EventDetailsPage />} />
+        </Routes>
+      </MemoryRouter>,
+      { store },
+    );
+
+    expect(await screen.findByText("Invitations")).toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Invited user UUID"),
+      "usr-2",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/events/evt-1/invitations", {
+        invitedUserId: "usr-2",
+      });
+    });
+  });
 });

--- a/frontend/src/pages/MyInvitationsPage.test.tsx
+++ b/frontend/src/pages/MyInvitationsPage.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { screen, waitFor } from "@testing-library/react";
+import { api } from "../shared/api/client";
+import { MyInvitationsPage } from "./MyInvitationsPage";
+import {
+  createTestStore,
+  renderWithProviders,
+} from "../test/renderWithProviders";
+
+describe("MyInvitationsPage", () => {
+  it("loads invitations and allows accepting pending invitation", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      data: [
+        {
+          id: "inv-1",
+          eventId: "evt-1",
+          invitedByUserId: "org-1",
+          invitedUserId: "usr-1",
+          status: "pending",
+          createdAt: "2099-01-01T00:00:00.000Z",
+          invitedByUser: { id: "org-1", email: "organizer@example.com" },
+          event: {
+            id: "evt-1",
+            title: "Private meetup",
+            eventDate: "2099-01-10T10:00:00.000Z",
+            visibility: "private",
+            organizerId: "org-1",
+          },
+        },
+      ],
+    });
+
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      data: {
+        id: "inv-1",
+        eventId: "evt-1",
+        invitedByUserId: "org-1",
+        invitedUserId: "usr-1",
+        status: "accepted",
+        createdAt: "2099-01-01T00:00:00.000Z",
+        invitedByUser: { id: "org-1", email: "organizer@example.com" },
+        event: {
+          id: "evt-1",
+          title: "Private meetup",
+          eventDate: "2099-01-10T10:00:00.000Z",
+          visibility: "private",
+          organizerId: "org-1",
+        },
+      },
+    });
+
+    const store = createTestStore({
+      auth: {
+        token: "token",
+        user: { email: "invitee@example.com" },
+        status: "idle",
+        error: null,
+        isAuthenticated: true,
+        isInitialized: true,
+      },
+      events: {
+        publicEvents: [],
+        myEvents: [],
+        selectedEvent: null,
+        status: "idle",
+        error: null,
+        assistantAnswer: null,
+        assistantStatus: "idle",
+        assistantError: null,
+      },
+    });
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/my-invitations"]}>
+        <Routes>
+          <Route path="/my-invitations" element={<MyInvitationsPage />} />
+        </Routes>
+      </MemoryRouter>,
+      { store },
+    );
+
+    expect(await screen.findByText("Private meetup")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith("/invitations/inv-1/accept", {});
+    });
+
+    expect(screen.getByText("accepted")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MyInvitationsPage.test.tsx
+++ b/frontend/src/pages/MyInvitationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { screen, waitFor } from "@testing-library/react";
@@ -10,6 +10,10 @@ import {
 } from "../test/renderWithProviders";
 
 describe("MyInvitationsPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("loads invitations and allows accepting pending invitation", async () => {
     vi.spyOn(api, "get").mockResolvedValue({
       data: [

--- a/frontend/src/pages/MyInvitationsPage.test.tsx
+++ b/frontend/src/pages/MyInvitationsPage.test.tsx
@@ -44,14 +44,6 @@ describe("MyInvitationsPage", () => {
         invitedUserId: "usr-1",
         status: "accepted",
         createdAt: "2099-01-01T00:00:00.000Z",
-        invitedByUser: { id: "org-1", email: "organizer@example.com" },
-        event: {
-          id: "evt-1",
-          title: "Private meetup",
-          eventDate: "2099-01-10T10:00:00.000Z",
-          visibility: "private",
-          organizerId: "org-1",
-        },
       },
     });
 
@@ -94,5 +86,6 @@ describe("MyInvitationsPage", () => {
     });
 
     expect(screen.getByText("accepted")).toBeInTheDocument();
+    expect(screen.getByText("Private meetup")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useAppDispatch, useAppSelector } from "../app/hooks";
+import {
+  acceptInvitation,
+  declineInvitation,
+  fetchMyInvitations,
+} from "../features/invitations/model/invitationsSlice";
+import { Button } from "../components/ui/Button";
+import { FormErrorText } from "../components/ui/FormErrorText";
+
+export function MyInvitationsPage() {
+  const dispatch = useAppDispatch();
+  const invitations = useAppSelector(
+    (state) => state.invitations.myInvitations,
+  );
+  const status = useAppSelector((state) => state.invitations.myStatus);
+  const error = useAppSelector((state) => state.invitations.myError);
+  const actionError = useAppSelector((state) => state.invitations.actionError);
+  const actionStatusByKey = useAppSelector(
+    (state) => state.invitations.actionStatusByKey,
+  );
+
+  useEffect(() => {
+    void dispatch(fetchMyInvitations());
+  }, [dispatch]);
+
+  return (
+    <section>
+      <h2 className="text-4xl font-bold text-slate-900">My Invitations</h2>
+      <p className="mt-2 text-lg text-slate-600">
+        Review your pending invites and decide whether to join private events.
+      </p>
+
+      {status === "loading" ? (
+        <p className="mt-6 text-slate-700">Loading invitations...</p>
+      ) : null}
+      {error ? <FormErrorText className="mt-6">{error}</FormErrorText> : null}
+      {actionError ? (
+        <FormErrorText className="mt-4">{actionError}</FormErrorText>
+      ) : null}
+
+      {status !== "loading" && invitations.length === 0 ? (
+        <p className="mt-6 text-slate-600">No invitations yet.</p>
+      ) : null}
+
+      {invitations.length > 0 ? (
+        <ul className="mt-6 space-y-3">
+          {invitations.map((invitation) => {
+            const isBusy =
+              actionStatusByKey[`respond:${invitation.id}`] === "loading";
+
+            const eventTitle = invitation.event?.title ?? "Private event";
+            const eventDate = invitation.event?.eventDate
+              ? new Date(invitation.event.eventDate).toLocaleString()
+              : "Date hidden until accepted";
+            const eventLocation =
+              invitation.event?.location ?? "Location hidden until accepted";
+
+            return (
+              <li
+                key={invitation.id}
+                className="rounded-xl border border-slate-200 bg-white p-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      {eventTitle}
+                    </h3>
+                    <p className="text-sm text-slate-600">{eventDate}</p>
+                    <p className="text-sm text-slate-600">{eventLocation}</p>
+                  </div>
+                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase text-slate-700">
+                    {invitation.status}
+                  </span>
+                </div>
+
+                <p className="mt-2 text-sm text-slate-600">
+                  Invited by:{" "}
+                  {invitation.invitedByUser?.email ??
+                    invitation.invitedByUserId}
+                </p>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {invitation.status === "pending" ? (
+                    <>
+                      <Button
+                        type="button"
+                        disabled={isBusy}
+                        onClick={() => {
+                          void dispatch(acceptInvitation(invitation.id));
+                        }}
+                        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 disabled:opacity-60"
+                      >
+                        {isBusy ? "Processing..." : "Accept"}
+                      </Button>
+                      <Button
+                        type="button"
+                        disabled={isBusy}
+                        onClick={() => {
+                          void dispatch(declineInvitation(invitation.id));
+                        }}
+                        className="rounded-lg border border-slate-300 bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 disabled:opacity-60"
+                      >
+                        {isBusy ? "Processing..." : "Decline"}
+                      </Button>
+                    </>
+                  ) : null}
+
+                  {invitation.event?.id ? (
+                    <Link
+                      to={`/events/${invitation.event.id}`}
+                      className="rounded-lg border border-indigo-300 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100"
+                    >
+                      Open event
+                    </Link>
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -107,9 +107,9 @@ export function MyInvitationsPage() {
                     </>
                   ) : null}
 
-                  {invitation.event?.id ? (
+                  {invitation.status === "accepted" && invitation.eventId ? (
                     <Link
-                      to={`/events/${invitation.event.id}`}
+                      to={`/events/${invitation.eventId}`}
                       className="rounded-lg border border-indigo-300 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100"
                     >
                       Open event

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -53,7 +53,7 @@ export function MyInvitationsPage() {
             const eventTitle = invitation.event?.title ?? "Private event";
             const eventDate = invitation.event?.eventDate
               ? new Date(invitation.event.eventDate).toLocaleString()
-              : "Date hidden until accepted";
+              : "Date unavailable";
             const eventLocation =
               invitation.event?.location ?? "Location hidden until accepted";
 

--- a/frontend/src/pages/MyInvitationsPage.tsx
+++ b/frontend/src/pages/MyInvitationsPage.tsx
@@ -40,7 +40,7 @@ export function MyInvitationsPage() {
         <FormErrorText className="mt-4">{actionError}</FormErrorText>
       ) : null}
 
-      {status !== "loading" && invitations.length === 0 ? (
+      {status === "idle" && !error && invitations.length === 0 ? (
         <p className="mt-6 text-slate-600">No invitations yet.</p>
       ) : null}
 

--- a/frontend/src/test/renderWithProviders.tsx
+++ b/frontend/src/test/renderWithProviders.tsx
@@ -4,10 +4,12 @@ import { configureStore } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { authReducer } from "../features/auth/authSlice";
 import { eventsReducer } from "../features/events/model/eventsSlice";
+import { invitationsReducer } from "../features/invitations/model/invitationsSlice";
 
 type TestState = {
   auth: ReturnType<typeof authReducer>;
   events: ReturnType<typeof eventsReducer>;
+  invitations: ReturnType<typeof invitationsReducer>;
 };
 
 export const createTestStore = (preloadedState?: Partial<TestState>) =>
@@ -15,6 +17,7 @@ export const createTestStore = (preloadedState?: Partial<TestState>) =>
     reducer: {
       auth: authReducer,
       events: eventsReducer,
+      invitations: invitationsReducer,
     },
     preloadedState: preloadedState as TestState | undefined,
   });
@@ -38,4 +41,3 @@ export const renderWithProviders = (
     ...render(ui, { wrapper: Wrapper }),
   };
 };
-

--- a/frontend/src/types/invitation.ts
+++ b/frontend/src/types/invitation.ts
@@ -1,0 +1,15 @@
+import type { EventItem, EventUser } from "./event";
+
+export type InvitationStatus = "pending" | "accepted" | "declined";
+
+export type InvitationItem = {
+  id: string;
+  eventId: string;
+  invitedByUserId: string;
+  invitedUserId: string;
+  status: InvitationStatus;
+  createdAt: string;
+  event?: EventItem;
+  invitedByUser?: EventUser;
+  invitedUser?: EventUser;
+};


### PR DESCRIPTION
### What changed

- Integrated the full private invitations work from branch feature/issue-private-invitations into main.

- Includes all three stages:

- [ ] feature/issue-private-invitations-be-core
- [ ] feature/issue-private-invitations-be-access
- [ ] feature/issue-private-invitations-fe


- Includes follow-up review fixes from frontend iteration:

- [ ] stale error cleanup in invitations state
- [ ] correct empty-state gating
- [ ] accepted-only event link behavior for invitees
- [ ] UUID input accessibility label/id linking
- [ ] invitation map typing alignment with runtime shape
- [ ] test cleanup with restoreAllMocks in MyInvitationsPage test

### Why

- Deliver the complete private invitations feature set to main in one integration PR.
- Keep backend access behavior and frontend UX aligned in a single release unit.

### Validation

- Frontend test suite run: npm run test:run
- Result: 44/44 tests passed.

### Risks/Notes

- This is an aggregate integration PR; review by stage/commit group is recommended.
- Previous frontend PR history is already included in this branch lineage.